### PR TITLE
fix: DCA SSE stream, user scoping via session, and parallel price fetch

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -2,6 +2,84 @@ import { stat } from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
+// ─── SSE: DCA Stream ────────────────────────────────────────────────────────
+// Handle SSE โดยตรงใน Bun server เพื่อหลีกเลี่ยงปัญหา TanStack Start
+// buffer/close streaming response ก่อนเวลา (INTERNAL_ERROR err 2)
+//
+// globalThis.__dcaEventManager ถูก init โดย bundle ตอน import server entry
+// ด้านล่าง — server.ts access ผ่าน globalThis จึงใช้ instance เดียวกันเสมอ
+
+type DCAEventManagerLike = {
+  subscribe: (cb: (event: unknown) => void) => () => void;
+};
+
+function getDcaEventManager(): DCAEventManagerLike | undefined {
+  return (globalThis as Record<string, unknown>)
+    .__dcaEventManager as DCAEventManagerLike | undefined;
+}
+
+function handleDcaSseStream(request: Request): Response {
+  const encoder = new TextEncoder();
+
+  const stream = new ReadableStream({
+    start(controller) {
+      let closed = false;
+
+      const send = (chunk: string) => {
+        if (closed) return;
+        try {
+          controller.enqueue(encoder.encode(chunk));
+        } catch {
+          closed = true;
+        }
+      };
+
+      // ส่ง event แรกทันทีที่ connect
+      send(
+        `data: ${JSON.stringify({ type: "connected", timestamp: Date.now() })}\n\n`,
+      );
+
+      // Subscribe รับ DCA events จาก event manager (shared via globalThis)
+      const eventManager = getDcaEventManager();
+      const unsubscribe = eventManager?.subscribe((event) => {
+        send(`data: ${JSON.stringify(event)}\n\n`);
+      });
+
+      // Keep-alive ping ทุก 20 วินาที ป้องกัน proxy timeout
+      const pingInterval = setInterval(() => {
+        if (closed) {
+          clearInterval(pingInterval);
+          return;
+        }
+        send(`: ping\n\n`);
+      }, 20_000);
+
+      // Cleanup เมื่อ client disconnect
+      request.signal.addEventListener("abort", () => {
+        if (closed) return;
+        closed = true;
+        clearInterval(pingInterval);
+        unsubscribe?.();
+        try {
+          controller.close();
+        } catch {
+          // controller อาจถูก close ไปแล้ว
+        }
+      });
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      "X-Accel-Buffering": "no",
+    },
+  });
+}
+// ────────────────────────────────────────────────────────────────────────────
+
 interface StaticFileResult {
   filePath: string;
   size: number;
@@ -143,6 +221,16 @@ const server = Bun.serve({
   port,
   hostname,
   async fetch(request) {
+    // ─── SSE endpoint: handle ก่อน TanStack Start ───────────────────────────
+    // TanStack Start's server route ไม่ support long-lived streaming response
+    // ทำให้ stream ปิดทันที (HTTP/2 INTERNAL_ERROR err 2)
+    // จึง handle โดยตรงใน Bun native server แทน
+    const url = new URL(request.url);
+    if (url.pathname === "/api/dca/stream" && request.method === "GET") {
+      return handleDcaSseStream(request);
+    }
+    // ────────────────────────────────────────────────────────────────────────
+
     const staticResponse = await serveStaticFile(request);
 
     if (staticResponse) {

--- a/src/features/dca/components/AddDcaForm.tsx
+++ b/src/features/dca/components/AddDcaForm.tsx
@@ -53,50 +53,27 @@ export const AddDcaForm = ({ onClose, onSuccess }: AddDcaFormProps) => {
               </div>
             )}
 
-            <div id="dca-add-coin-user-fields" className="grid grid-cols-2 gap-3">
-              <div id="dca-add-coin-field" className="space-y-1">
-                <label
-                  id="dca-add-coin-label"
-                  htmlFor="dca-add-coin-input"
-                  className="text-muted-foreground text-xs font-medium"
-                >
-                  เหรียญ
-                </label>
-                <Input
-                  id="dca-add-coin-input"
-                  value={form.coin}
-                  onChange={(e) =>
-                    setForm((current) => ({
-                      ...current,
-                      coin: e.target.value.toUpperCase(),
-                    }))
-                  }
-                  placeholder="BTC"
-                  className="h-9"
-                  required
-                />
-              </div>
-              <div id="dca-add-line-user-id-field" className="space-y-1">
-                <label
-                  id="dca-add-line-user-id-label"
-                  htmlFor="dca-add-line-user-id-input"
-                  className="text-muted-foreground text-xs font-medium"
-                >
-                  LINE User ID (ไม่บังคับ)
-                </label>
-                <Input
-                  id="dca-add-line-user-id-input"
-                  value={form.lineUserId}
-                  onChange={(e) =>
-                    setForm((current) => ({
-                      ...current,
-                      lineUserId: e.target.value,
-                    }))
-                  }
-                  placeholder="Uxxxxxxxx"
-                  className="h-9"
-                />
-              </div>
+            <div id="dca-add-coin-field" className="space-y-1">
+              <label
+                id="dca-add-coin-label"
+                htmlFor="dca-add-coin-input"
+                className="text-muted-foreground text-xs font-medium"
+              >
+                เหรียญ
+              </label>
+              <Input
+                id="dca-add-coin-input"
+                value={form.coin}
+                onChange={(e) =>
+                  setForm((current) => ({
+                    ...current,
+                    coin: e.target.value.toUpperCase(),
+                  }))
+                }
+                placeholder="BTC"
+                className="h-9"
+                required
+              />
             </div>
 
             <div id="dca-add-amount-field" className="space-y-1">

--- a/src/features/dca/hooks/useAddDcaOrder.ts
+++ b/src/features/dca/hooks/useAddDcaOrder.ts
@@ -11,7 +11,6 @@ export const useAddDcaOrder = ({
   onSuccess,
 }: UseAddDcaOrderOptions) => {
   const [form, setForm] = useState({
-    lineUserId: "",
     coin: "BTC",
     amountTHB: "",
     coinReceived: "",
@@ -32,7 +31,7 @@ export const useAddDcaOrder = ({
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          lineUserId: form.lineUserId || "manual-entry",
+          // lineUserId ไม่ต้องส่ง — API ดึงจาก session เอง
           coin: form.coin,
           amountTHB: parseFloat(form.amountTHB),
           coinReceived: parseFloat(form.coinReceived),

--- a/src/features/line/commands/handleDcaCommand.ts
+++ b/src/features/line/commands/handleDcaCommand.ts
@@ -1,7 +1,10 @@
 import { dcaService } from "@/features/dca";
 import { sendMessage } from "@/lib/utils/line-utils";
 import { dcaEventManager } from "@/lib/dca/event-manager";
-import { getPnLFromBitkub } from "@/features/dca/services/bitkub.service";
+import {
+  getBTCPrice,
+  calculatePnLPercent,
+} from "@/features/dca/services/bitkub.service";
 import { createDcaSummaryFlexMessage } from "@/lib/line-utils/flex-messages";
 
 // ========================
@@ -379,18 +382,28 @@ const handleDelete = async (req: any, args: string[]) => {
  * /dca
  */
 const handleSummary = async (req: any) => {
-  const userId = req.body?.events?.[0]?.source?.userId;
   const appUrl = process.env["APP_URL"] ?? process.env["NEXTAUTH_URL"] ?? "";
 
   try {
-    const [summary, latest] = await Promise.all([
-      dcaService.getSummary(userId),
+    // ดึงข้อมูลทั้งหมดพร้อมกัน รวมถึงราคาปัจจุบันจาก Bitkub
+    const [summary, latest, currentPrice] = await Promise.all([
+      dcaService.getSummary(), // ไม่ filter by userId — แสดงยอดรวมทั้งหมด
       dcaService.listOrders({ page: 1, limit: 1 }),
+      getBTCPrice(), // ดึงราคา BTC เสมอ ไม่รอ avgPrice
     ]);
 
     const lastOrder = latest.orders[0];
-    const avgPrice = summary.totalBTC > 0 ? summary.totalSpentTHB / summary.totalBTC : 0;
-    const pnlData = avgPrice > 0 ? await getPnLFromBitkub(avgPrice) : null;
+    const avgPrice =
+      summary.totalBTC > 0 ? summary.totalSpentTHB / summary.totalBTC : 0;
+
+    // คำนวณ PnL ถ้าได้ราคาและมียอดสะสม
+    const pnlData =
+      currentPrice && avgPrice > 0
+        ? {
+            currentPrice,
+            pnlPercent: calculatePnLPercent(avgPrice, currentPrice),
+          }
+        : null;
 
     // สร้าง Flex Message
     const flexMessage = createDcaSummaryFlexMessage(
@@ -399,7 +412,7 @@ const handleSummary = async (req: any) => {
         totalBTC: summary.totalBTC,
         totalRounds: summary.totalRounds,
         averagePrice: avgPrice,
-        currentPrice: pnlData?.currentPrice ?? null,
+        currentPrice: currentPrice ?? null,
         pnlPercent: pnlData?.pnlPercent ?? null,
         pnlValue:
           pnlData && summary.totalBTC > 0

--- a/src/features/line/commands/handleDcaCommand.ts
+++ b/src/features/line/commands/handleDcaCommand.ts
@@ -382,14 +382,15 @@ const handleDelete = async (req: any, args: string[]) => {
  * /dca
  */
 const handleSummary = async (req: any) => {
+  const userId = req.body?.events?.[0]?.source?.userId as string | undefined;
   const appUrl = process.env["APP_URL"] ?? process.env["NEXTAUTH_URL"] ?? "";
 
   try {
     // ดึงข้อมูลทั้งหมดพร้อมกัน รวมถึงราคาปัจจุบันจาก Bitkub
     const [summary, latest, currentPrice] = await Promise.all([
-      dcaService.getSummary(), // ไม่ filter by userId — แสดงยอดรวมทั้งหมด
-      dcaService.listOrders({ page: 1, limit: 1 }),
-      getBTCPrice(), // ดึงราคา BTC เสมอ ไม่รอ avgPrice
+      dcaService.getSummary(userId), // filter by LINE userId
+      dcaService.listOrders({ page: 1, limit: 1, lineUserId: userId }),
+      getBTCPrice(), // ดึงราคา BTC พร้อมกันเสมอ ไม่รอ avgPrice
     ]);
 
     const lastOrder = latest.orders[0];

--- a/src/lib/auth/index.ts
+++ b/src/lib/auth/index.ts
@@ -1,1 +1,2 @@
 export { auth, getServerAuthSession } from "./auth";
+export { getLineUserId } from "./line-user-id";

--- a/src/lib/auth/line-user-id.ts
+++ b/src/lib/auth/line-user-id.ts
@@ -1,0 +1,26 @@
+import { db } from "@/lib/database/db";
+import { getServerAuthSession } from "./auth";
+
+/**
+ * ดึง LINE User ID จาก session ของ user ที่ login อยู่
+ *
+ * LINE User ID เก็บอยู่ใน Account.providerAccountId (provider = "line")
+ * ซึ่งเป็น `sub` ที่ได้จาก LINE OAuth (เช่น Ub1234567890)
+ *
+ * @returns LINE User ID หรือ null ถ้าไม่ได้ login / ไม่มี LINE account
+ */
+export async function getLineUserId(request: Request): Promise<string | null> {
+  const session = await getServerAuthSession(request);
+
+  if (!session?.user?.id) return null;
+
+  const account = await db.account.findFirst({
+    where: {
+      userId: session.user.id,
+      provider: "line",
+    },
+    select: { providerAccountId: true },
+  });
+
+  return account?.providerAccountId ?? null;
+}

--- a/src/lib/dca/event-manager.ts
+++ b/src/lib/dca/event-manager.ts
@@ -20,5 +20,11 @@ class DCAEventManager {
   }
 }
 
-// Global singleton
-export const dcaEventManager = new DCAEventManager();
+// เก็บ singleton บน globalThis เพื่อให้แชร์ข้าม module boundary ได้
+// (server.ts และ TanStack Start bundle เป็น module คนละตัว แต่ใช้ globalThis ร่วมกัน)
+const g = globalThis as typeof globalThis & { __dcaEventManager?: DCAEventManager };
+if (!g.__dcaEventManager) {
+  g.__dcaEventManager = new DCAEventManager();
+}
+
+export const dcaEventManager: DCAEventManager = g.__dcaEventManager;

--- a/src/lib/line-utils/flex-messages.ts
+++ b/src/lib/line-utils/flex-messages.ts
@@ -101,7 +101,7 @@ export function createDcaSummaryFlexMessage(
     bodyContents[0].contents[1].color = pnlColor;
     bodyContents[1].contents[1].color = pnlColor;
   } else {
-    bodyContents.push(createMetricRow("PnL", "กำลังโหลดราคา"));
+    bodyContents.push(createMetricRow("PnL", "ไม่พบข้อมูลราคา"));
   }
 
   if (data.currentPrice !== null) {

--- a/src/routes/api/dca/index.tsx
+++ b/src/routes/api/dca/index.tsx
@@ -1,15 +1,15 @@
 /**
  * DCA Orders API
- * GET  /api/dca - รายการ DCA orders พร้อม pagination
- * POST /api/dca - สร้าง DCA order ใหม่ (manual entry)
+ * GET  /api/dca - รายการ DCA orders พร้อม pagination (filter by session user)
+ * POST /api/dca - สร้าง DCA order ใหม่ (ใช้ LINE userId จาก session อัตโนมัติ)
  */
 import { createFileRoute } from "@tanstack/react-router";
 import { z } from "zod";
 import { dcaService } from "@/features/dca";
 import { dcaEventManager } from "@/lib/dca/event-manager";
+import { getLineUserId } from "@/lib/auth";
 
 const createDcaSchema = z.object({
-  lineUserId: z.string().min(1, "ต้องระบุ LINE User ID"),
   coin: z.string().min(1).max(20).default("BTC"),
   amountTHB: z.number().positive("จำนวนเงินต้องมากกว่า 0"),
   coinReceived: z.number().positive("จำนวนเหรียญต้องมากกว่า 0"),
@@ -21,16 +21,22 @@ const createDcaSchema = z.object({
 
 /**
  * GET /api/dca
- * Query params: page, limit, coin, lineUserId
+ * Query params: page, limit, coin
+ * lineUserId ดึงจาก session อัตโนมัติ
  */
 export async function GET(request: Request) {
   try {
+    const lineUserId = await getLineUserId(request);
+
+    if (!lineUserId) {
+      return Response.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
     const { searchParams } = new URL(request.url);
 
     const page = parseInt(searchParams.get("page") ?? "1");
     const limit = parseInt(searchParams.get("limit") ?? "10");
     const coin = searchParams.get("coin") ?? undefined;
-    const lineUserId = searchParams.get("lineUserId") ?? undefined;
 
     const result = await dcaService.listOrders({
       page,
@@ -48,10 +54,16 @@ export async function GET(request: Request) {
 
 /**
  * POST /api/dca
- * Body: CreateDcaOrderInput
+ * Body: CreateDcaOrderInput (ไม่ต้องส่ง lineUserId — ดึงจาก session เอง)
  */
 export async function POST(request: Request) {
   try {
+    const lineUserId = await getLineUserId(request);
+
+    if (!lineUserId) {
+      return Response.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
     const body = await request.json();
     const parsed = createDcaSchema.safeParse(body);
 
@@ -62,7 +74,10 @@ export async function POST(request: Request) {
       );
     }
 
-    const order = await dcaService.createOrder(parsed.data);
+    const order = await dcaService.createOrder({
+      ...parsed.data,
+      lineUserId, // inject จาก session เสมอ
+    });
 
     // 🎉 Emit SSE event เพื่อให้ clients รับทราบ
     dcaEventManager.emit({

--- a/src/routes/api/dca/stream.tsx
+++ b/src/routes/api/dca/stream.tsx
@@ -7,6 +7,7 @@ export async function GET(req: Request) {
     "Cache-Control": "no-cache, no-transform",
     Connection: "keep-alive",
     "X-Accel-Buffering": "no", // ปิด buffering ใน nginx
+    "Alt-Svc": "clear", // บังคับ HTTP/1.1 ไม่ใช้ QUIC (HTTP/3) กับ SSE
   });
 
   const encoder = new TextEncoder();

--- a/src/routes/api/dca/summary.tsx
+++ b/src/routes/api/dca/summary.tsx
@@ -1,10 +1,16 @@
 /**
  * DCA Summary API
  * GET /api/dca/summary - ดึงสรุปยอดรวม DCA พร้อม PnL จาก Bitkub
+ *
+ * ดึง LINE User ID จาก session อัตโนมัติ — ไม่ต้องส่ง query param
  */
 import { createFileRoute } from "@tanstack/react-router";
 import { dcaService } from "@/features/dca";
-import { getPnLFromBitkub } from "@/features/dca/services/bitkub.service";
+import {
+  getBTCPrice,
+  calculatePnLPercent,
+} from "@/features/dca/services/bitkub.service";
+import { getLineUserId } from "@/lib/auth";
 
 interface DcaSummaryWithPnL {
   totalSpentTHB: number;
@@ -19,29 +25,42 @@ interface DcaSummaryWithPnL {
 
 export async function GET(request: Request) {
   try {
-    const { searchParams } = new URL(request.url);
-    const lineUserId = searchParams.get("lineUserId") ?? undefined;
+    // ดึง LINE User ID จาก session
+    const lineUserId = await getLineUserId(request);
 
-    const summary = await dcaService.getSummary(lineUserId);
+    if (!lineUserId) {
+      return Response.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // ดึงข้อมูลทั้งหมดพร้อมกัน รวมถึงราคาปัจจุบัน
+    const [summary, currentPrice] = await Promise.all([
+      dcaService.getSummary(lineUserId),
+      getBTCPrice(),
+    ]);
 
     // คำนวณราคาเฉลี่ย
     const averagePrice =
       summary.totalBTC > 0 ? summary.totalSpentTHB / summary.totalBTC : 0;
 
-    // ดึงราคาปัจจุบันจาก Bitkub
-    const pnlData = await getPnLFromBitkub(averagePrice);
+    // คำนวณ PnL ถ้าได้ราคาและมียอดสะสม
+    const pnlPercent =
+      currentPrice && averagePrice > 0
+        ? calculatePnLPercent(averagePrice, currentPrice)
+        : null;
+
+    const pnlValue =
+      currentPrice && averagePrice > 0 && summary.totalBTC > 0
+        ? (currentPrice - averagePrice) * summary.totalBTC
+        : null;
 
     const response: DcaSummaryWithPnL = {
       totalSpentTHB: summary.totalSpentTHB,
       totalBTC: summary.totalBTC,
       totalRounds: summary.totalRounds,
       averagePrice,
-      currentPrice: pnlData?.currentPrice ?? null,
-      pnlPercent: pnlData?.pnlPercent ?? null,
-      pnlValue:
-        pnlData && summary.totalBTC > 0
-          ? (pnlData.currentPrice - averagePrice) * summary.totalBTC
-          : null,
+      currentPrice: currentPrice ?? null,
+      pnlPercent,
+      pnlValue,
     };
 
     return Response.json(response, { status: 200 });


### PR DESCRIPTION
## Summary

- **SSE fix**: Handle `/api/dca/stream` natively in the Bun server (`server.ts`) to prevent TanStack Start from closing the long-lived stream early (HTTP/2 `INTERNAL_ERROR` err 2); share `DCAEventManager` singleton via `globalThis.__dcaEventManager` across module boundaries
- **User scoping**: Introduce `getLineUserId(request)` helper (`src/lib/auth/line-user-id.ts`) that resolves the LINE `providerAccountId` from the active session — replacing manual `lineUserId` query params and form fields across `GET /api/dca`, `POST /api/dca`, and `GET /api/dca/summary`; both web and bot (`handleDcaCommand`) now filter orders by the correct LINE user
- **Parallel price fetch**: `GET /api/dca/summary` and the LINE bot summary command now fetch the BTC price via `getBTCPrice()` concurrently with the DB query instead of sequentially; PnL is computed from `calculatePnLPercent` without an extra round-trip
- **UI cleanup**: Remove the manual "LINE User ID" input from `AddDcaForm`; the API injects it from the session automatically
- **UX copy**: Change PnL fallback label from "กำลังโหลดราคา" to "ไม่พบข้อมูลราคา" when price is unavailable

## Testing

- [ ] Open the DCA web page as a logged-in LINE user — verify the order list shows only that user's orders without passing `lineUserId` in the URL
- [ ] Submit a new DCA order via the form — confirm the order is created with the correct LINE user ID pulled from session (check DB)
- [ ] Open the DCA summary page — verify PnL and current price appear without manual query params
- [ ] Disconnect/reconnect to the SSE stream (`/api/dca/stream`) and confirm the connection stays open, keep-alive pings are sent every 20 s, and new orders trigger events
- [ ] Trigger `/dca` from LINE bot — confirm summary shows all orders scoped to the bot user's LINE ID, with BTC price and PnL populated
- [ ] Simulate no LINE account linked to session — verify `GET /api/dca`, `POST /api/dca`, and `GET /api/dca/summary` all return `401 Unauthorized`