### PR TITLE
feat: add DCA history import/export (CSV/JSON/Excel) and multi-round delete

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -47,6 +47,7 @@
         "tailwindcss": "^4.2.2",
         "tweakpane": "^4.0.5",
         "uuid": "^13.0.0",
+        "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
         "zod": "4.1.12",
         "zod-to-json-schema": "^3.25.1",
       },
@@ -1719,6 +1720,8 @@
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
     "ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
+
+    "xlsx": ["xlsx@https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz", { "bin": { "xlsx": "./bin/xlsx.njs" } }, "sha512-oLDq3jw7AcLqKWH2AhCpVTZl8mf6X2YReP+Neh0SJUzV/BdZYjth94tG5toiMB1PPrYtxOCfaoUCkvtuH+3AJA=="],
 
     "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
 

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "tailwindcss": "^4.2.2",
     "tweakpane": "^4.0.5",
     "uuid": "^13.0.0",
+    "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
     "zod": "4.1.12",
     "zod-to-json-schema": "^3.25.1"
   },

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -254,6 +254,7 @@ model DcaOrder {
   createdAt    DateTime  @default(now()) @map("created_at")
   updatedAt    DateTime  @updatedAt @map("updated_at")
 
+  @@unique([lineUserId, coin, executedAt])
   @@index([orderId])
   @@index([lineUserId, executedAt])
   @@index([coin, executedAt])

--- a/src/features/dca/components/DcaExportButtons.tsx
+++ b/src/features/dca/components/DcaExportButtons.tsx
@@ -1,0 +1,98 @@
+import { useState } from "react";
+import { Download, FileJson, FileSpreadsheet, FileText } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type { ExportFormat } from "@/features/dca/types";
+
+interface ExportOption {
+  format: ExportFormat;
+  label: string;
+  icon: React.ReactNode;
+}
+
+const EXPORT_OPTIONS: ExportOption[] = [
+  { format: "csv",  label: "CSV",   icon: <FileText className="h-3.5 w-3.5" /> },
+  { format: "json", label: "JSON",  icon: <FileJson className="h-3.5 w-3.5" /> },
+  { format: "xlsx", label: "Excel", icon: <FileSpreadsheet className="h-3.5 w-3.5" /> },
+];
+
+interface DcaExportButtonsProps {
+  disabled?: boolean;
+}
+
+export const DcaExportButtons = ({ disabled }: DcaExportButtonsProps) => {
+  const [loading, setLoading] = useState<ExportFormat | null>(null);
+
+  const handleExport = async (format: ExportFormat) => {
+    if (loading) return;
+    setLoading(format);
+    try {
+      const res = await fetch(`/api/dca/export?format=${format}`);
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(
+          (err as { error?: string }).error ?? "ไม่สามารถส่งออกได้",
+        );
+      }
+
+      const blob = await res.blob();
+
+      // ดึง filename จาก Content-Disposition header
+      const disposition = res.headers.get("content-disposition") ?? "";
+      const match = disposition.match(/filename="?([^";\s]+)"?/);
+      const filename = match?.[1] ?? `dca-history.${format}`;
+
+      // trigger browser download
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "เกิดข้อผิดพลาด");
+    } finally {
+      setLoading(null);
+    }
+  };
+
+  return (
+    <div
+      id="dca-export-buttons"
+      className="flex items-center gap-1"
+      role="group"
+      aria-label="ส่งออกข้อมูล"
+    >
+      <span
+        id="dca-export-label"
+        className="text-muted-foreground mr-1 flex items-center gap-1 text-xs"
+      >
+        <Download className="h-3.5 w-3.5" />
+        ส่งออก
+      </span>
+      {EXPORT_OPTIONS.map(({ format, label, icon }) => (
+        <Button
+          key={format}
+          id={`dca-export-${format}-button`}
+          variant="outline"
+          size="sm"
+          onClick={() => void handleExport(format)}
+          disabled={disabled || loading !== null}
+          className="h-8 gap-1.5 px-2.5 text-xs"
+          aria-label={`ส่งออกเป็น ${label}`}
+        >
+          {loading === format ? (
+            <span
+              className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-current border-t-transparent"
+              aria-hidden
+            />
+          ) : (
+            icon
+          )}
+          {label}
+        </Button>
+      ))}
+    </div>
+  );
+};

--- a/src/features/dca/components/DcaImportModal.tsx
+++ b/src/features/dca/components/DcaImportModal.tsx
@@ -1,0 +1,332 @@
+import { useCallback, useRef, useState } from "react";
+import {
+  AlertCircle,
+  CheckCircle2,
+  FileJson,
+  FileSpreadsheet,
+  FileText,
+  Upload,
+  X,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import type { ImportResult } from "@/features/dca/types";
+
+interface DcaImportModalProps {
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+const ACCEPTED_EXTS = [".csv", ".json", ".xlsx"] as const;
+const ACCEPTED_MIME = [
+  "text/csv",
+  "application/json",
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+].join(",");
+
+const FileIcon = ({ name }: { name: string }) => {
+  const ext = name.split(".").pop()?.toLowerCase();
+  if (ext === "csv") return <FileText className="h-5 w-5 text-green-400" />;
+  if (ext === "json") return <FileJson className="h-5 w-5 text-yellow-400" />;
+  return <FileSpreadsheet className="h-5 w-5 text-emerald-400" />;
+};
+
+type Step = "select" | "uploading" | "result";
+
+export const DcaImportModal = ({ onClose, onSuccess }: DcaImportModalProps) => {
+  const [step, setStep] = useState<Step>("select");
+  const [file, setFile] = useState<File | null>(null);
+  const [dragOver, setDragOver] = useState(false);
+  const [result, setResult] = useState<ImportResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // ─── File handling ────────────────────────────────────────────────────────
+
+  const acceptFile = (f: File) => {
+    const ext = f.name.split(".").pop()?.toLowerCase();
+    if (!ACCEPTED_EXTS.includes(`.${ext}` as (typeof ACCEPTED_EXTS)[number])) {
+      setError("รองรับเฉพาะไฟล์ .csv, .json, .xlsx เท่านั้น");
+      return;
+    }
+    setError(null);
+    setFile(f);
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const f = e.target.files?.[0];
+    if (f) acceptFile(f);
+  };
+
+  const handleDrop = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setDragOver(false);
+    const f = e.dataTransfer.files?.[0];
+    if (f) acceptFile(f);
+  }, []);
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+    setDragOver(true);
+  };
+
+  const handleDragLeave = () => setDragOver(false);
+
+  // ─── Upload ───────────────────────────────────────────────────────────────
+
+  const handleUpload = async () => {
+    if (!file) return;
+    setStep("uploading");
+    setError(null);
+
+    try {
+      const fd = new FormData();
+      fd.append("file", file);
+
+      const res = await fetch("/api/dca/import", {
+        method: "POST",
+        body: fd,
+      });
+
+      const data = (await res.json()) as ImportResult & { error?: string };
+
+      if (!res.ok) {
+        throw new Error(data.error ?? "นำเข้าไม่สำเร็จ");
+      }
+
+      setResult(data);
+      setStep("result");
+
+      if (data.imported > 0) {
+        onSuccess();
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "เกิดข้อผิดพลาด");
+      setStep("select");
+    }
+  };
+
+  // ─── Render ───────────────────────────────────────────────────────────────
+
+  return (
+    <div
+      id="dca-import-modal-overlay"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm"
+      onClick={(e) => e.target === e.currentTarget && onClose()}
+    >
+      <Card
+        id="dca-import-modal"
+        className="border-border w-full max-w-md"
+        role="dialog"
+        aria-modal="true"
+        aria-label="นำเข้าประวัติคำสั่งซื้อ Auto DCA"
+      >
+        {/* Header */}
+        <div
+          id="dca-import-modal-header"
+          className="flex items-center justify-between border-b border-border px-5 py-4"
+        >
+          <div className="flex items-center gap-2">
+            <Upload className="h-5 w-5 text-yellow-400" />
+            <h2 className="text-base font-semibold">นำเข้าประวัติ Auto DCA</h2>
+          </div>
+          <Button
+            id="dca-import-modal-close"
+            variant="ghost"
+            size="sm"
+            onClick={onClose}
+            className="h-8 w-8 p-0"
+            aria-label="ปิด"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+
+        <CardContent id="dca-import-modal-body" className="p-5">
+          {step === "select" && (
+            <div id="dca-import-step-select" className="space-y-4">
+              {/* Dropzone */}
+              <div
+                id="dca-import-dropzone"
+                onClick={() => inputRef.current?.click()}
+                onDrop={handleDrop}
+                onDragOver={handleDragOver}
+                onDragLeave={handleDragLeave}
+                className={`flex cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed px-6 py-10 transition-colors ${
+                  dragOver
+                    ? "border-yellow-400 bg-yellow-400/10"
+                    : "border-border hover:border-yellow-400/50 hover:bg-muted/30"
+                }`}
+              >
+                <Upload
+                  className={`mb-3 h-8 w-8 ${dragOver ? "text-yellow-400" : "text-muted-foreground"}`}
+                />
+                <p className="text-sm font-medium">
+                  วาง หรือคลิกเพื่อเลือกไฟล์
+                </p>
+                <p className="text-muted-foreground mt-1 text-xs">
+                  รองรับ .csv, .json, .xlsx
+                </p>
+                <input
+                  ref={inputRef}
+                  id="dca-import-file-input"
+                  type="file"
+                  accept={ACCEPTED_MIME}
+                  className="hidden"
+                  onChange={handleFileChange}
+                />
+              </div>
+
+              {/* Selected file */}
+              {file && (
+                <div
+                  id="dca-import-selected-file"
+                  className="bg-muted/40 flex items-center gap-3 rounded-lg px-4 py-3"
+                >
+                  <FileIcon name={file.name} />
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium">{file.name}</p>
+                    <p className="text-muted-foreground text-xs">
+                      {(file.size / 1024).toFixed(1)} KB
+                    </p>
+                  </div>
+                  <Button
+                    id="dca-import-remove-file"
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 w-7 shrink-0 p-0"
+                    onClick={() => setFile(null)}
+                    aria-label="ลบไฟล์ที่เลือก"
+                  >
+                    <X className="h-3.5 w-3.5" />
+                  </Button>
+                </div>
+              )}
+
+              {/* Error */}
+              {error && (
+                <div
+                  id="dca-import-select-error"
+                  className="flex items-center gap-2 rounded-lg bg-red-500/10 px-4 py-3 text-sm text-red-400"
+                >
+                  <AlertCircle className="h-4 w-4 shrink-0" />
+                  {error}
+                </div>
+              )}
+
+              {/* Format hint */}
+              <div
+                id="dca-import-format-hint"
+                className="rounded-lg bg-muted/30 px-4 py-3 text-xs text-muted-foreground space-y-1"
+              >
+                <p className="font-medium text-foreground">คอลัมน์ที่จำเป็น:</p>
+                <p>
+                  <span className="font-mono text-yellow-400">executedAt</span>,{" "}
+                  <span className="font-mono text-yellow-400">coin</span>,{" "}
+                  <span className="font-mono text-yellow-400">amountTHB</span>,{" "}
+                  <span className="font-mono text-yellow-400">coinReceived</span>,{" "}
+                  <span className="font-mono text-yellow-400">pricePerCoin</span>
+                </p>
+                <p>
+                  คอลัมน์เสริม:{" "}
+                  <span className="font-mono">status</span>,{" "}
+                  <span className="font-mono">note</span>
+                </p>
+              </div>
+
+              {/* Actions */}
+              <div className="flex justify-end gap-2 pt-1">
+                <Button variant="outline" size="sm" onClick={onClose}>
+                  ยกเลิก
+                </Button>
+                <Button
+                  id="dca-import-submit-button"
+                  size="sm"
+                  disabled={!file}
+                  onClick={() => void handleUpload()}
+                  className="gap-2 bg-yellow-500 text-black hover:bg-yellow-400 disabled:opacity-50"
+                >
+                  <Upload className="h-4 w-4" />
+                  นำเข้า
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {step === "uploading" && (
+            <div
+              id="dca-import-step-uploading"
+              className="flex flex-col items-center justify-center py-12 gap-4"
+            >
+              <span className="h-10 w-10 animate-spin rounded-full border-4 border-yellow-400 border-t-transparent" />
+              <p className="text-sm text-muted-foreground">กำลังนำเข้าข้อมูล…</p>
+            </div>
+          )}
+
+          {step === "result" && result && (
+            <div id="dca-import-step-result" className="space-y-4">
+              {/* Summary */}
+              <div
+                id="dca-import-result-summary"
+                className={`flex items-start gap-3 rounded-lg px-4 py-4 ${
+                  result.imported > 0
+                    ? "bg-green-500/10"
+                    : "bg-muted/40"
+                }`}
+              >
+                {result.imported > 0 ? (
+                  <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-green-400" />
+                ) : (
+                  <AlertCircle className="mt-0.5 h-5 w-5 shrink-0 text-muted-foreground" />
+                )}
+                <div className="space-y-0.5">
+                  <p className="text-sm font-medium">
+                    นำเข้าสำเร็จ{" "}
+                    <span className="text-green-400">{result.imported}</span> รายการ
+                    {result.skipped > 0 && (
+                      <>
+                        {" "}
+                        · ข้าม{" "}
+                        <span className="text-red-400">{result.skipped}</span> รายการ
+                      </>
+                    )}
+                  </p>
+                </div>
+              </div>
+
+              {/* Error list */}
+              {result.errors.length > 0 && (
+                <div id="dca-import-result-errors" className="space-y-2">
+                  <p className="text-xs font-medium text-red-400">
+                    รายการที่ข้าม ({result.errors.length}):
+                  </p>
+                  <ul className="max-h-40 overflow-y-auto rounded-lg bg-red-500/10 px-4 py-3 space-y-1">
+                    {result.errors.map((e, i) => (
+                      <li
+                        key={i}
+                        className="text-xs text-red-300"
+                      >
+                        • {e}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              <div className="flex justify-end pt-1">
+                <Button
+                  id="dca-import-done-button"
+                  size="sm"
+                  onClick={onClose}
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  เสร็จสิ้น
+                </Button>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};

--- a/src/features/dca/services/dca.service.ts
+++ b/src/features/dca/services/dca.service.ts
@@ -16,11 +16,11 @@ const generateOrderId = (coin: string, round: number): string => {
 };
 
 /**
- * ดึงรอบถัดไปสำหรับเหรียญที่ระบุ (นับจาก DCA orders ที่มีอยู่แล้ว)
+ * ดึงรอบถัดไปสำหรับ user และเหรียญที่ระบุ (นับแยกตาม lineUserId)
  */
-const getNextRound = async (coin: string): Promise<number> => {
+const getNextRound = async (coin: string, lineUserId: string): Promise<number> => {
   const latest = await db.dcaOrder.findFirst({
-    where: { coin: coin.toUpperCase() },
+    where: { coin: coin.toUpperCase(), lineUserId },
     orderBy: { round: "desc" },
     select: { round: true },
   });
@@ -32,7 +32,7 @@ const getNextRound = async (coin: string): Promise<number> => {
  */
 const createOrder = async (input: CreateDcaOrderInput) => {
   const coin = input.coin.toUpperCase();
-  const round = await getNextRound(coin);
+  const round = await getNextRound(coin, input.lineUserId);
   const orderId = generateOrderId(coin, round);
 
   return db.dcaOrder.create({
@@ -92,10 +92,41 @@ const getOrderById = async (id: string) => {
 };
 
 /**
- * ดึง DCA order ด้วย round number
+ * ดึง DCA order ด้วย round number (scope ตาม lineUserId เสมอ)
  */
-const findByRound = async (round: number) => {
-  return db.dcaOrder.findFirst({ where: { round } });
+const findByRound = async (round: number, lineUserId: string) => {
+  return db.dcaOrder.findFirst({ where: { round, lineUserId } });
+};
+
+/**
+ * ดึง DCA orders หลายรอบพร้อมกัน (ใช้สำหรับ multi-delete)
+ */
+const findByRounds = async (rounds: number[], lineUserId: string) => {
+  return db.dcaOrder.findMany({
+    where: { round: { in: rounds }, lineUserId },
+    orderBy: { round: "asc" },
+  });
+};
+
+/**
+ * ตรวจหา orders ที่ซ้ำกัน (ใช้ก่อน import)
+ * key = lineUserId + coin + executedAt
+ */
+const findDuplicates = async (
+  lineUserId: string,
+  candidates: { coin: string; executedAt: Date }[],
+) => {
+  if (candidates.length === 0) return [];
+  return db.dcaOrder.findMany({
+    where: {
+      lineUserId,
+      OR: candidates.map((c) => ({
+        coin: c.coin,
+        executedAt: c.executedAt,
+      })),
+    },
+    select: { coin: true, executedAt: true },
+  });
 };
 
 /**
@@ -213,6 +244,16 @@ const parseBitkubDcaMessage = (
 };
 
 /**
+ * ดึง DCA orders ทั้งหมดของ user โดยไม่มี pagination (ใช้สำหรับ export)
+ */
+const listAllOrders = async (lineUserId: string) => {
+  return db.dcaOrder.findMany({
+    where: { lineUserId },
+    orderBy: { executedAt: "desc" },
+  });
+};
+
+/**
  * สรุปยอดรวมทั้งหมด
  */
 const getSummary = async (lineUserId?: string) => {
@@ -241,8 +282,11 @@ const getSummary = async (lineUserId?: string) => {
 export const dcaService = {
   createOrder,
   listOrders,
+  listAllOrders,
   getOrderById,
   findByRound,
+  findByRounds,
+  findDuplicates,
   deleteOrder,
   parseBitkubDcaMessage,
   getSummary,

--- a/src/features/dca/types/index.ts
+++ b/src/features/dca/types/index.ts
@@ -60,3 +60,28 @@ export interface ParsedBitkubDcaMessage {
   coinReceived: number;
   executedAt: Date;
 }
+
+// ─── Export / Import ───────────────────────────────────────────────────────────
+
+/** รูปแบบแถวข้อมูลสำหรับ export (flat row ที่ใช้ใน CSV / Excel / JSON) */
+export interface DcaExportRow {
+  orderId: string;
+  executedAt: string;       // ISO 8601 string
+  coin: string;
+  amountTHB: number;
+  coinReceived: number;
+  pricePerCoin: number;
+  round: number;
+  status: string;
+  note: string;
+}
+
+/** รูปแบบไฟล์ที่รองรับ */
+export type ExportFormat = "csv" | "json" | "xlsx";
+
+/** ผลลัพธ์จากการ import */
+export interface ImportResult {
+  imported: number;
+  skipped: number;
+  errors: string[];
+}

--- a/src/features/line/commands/handleDcaCommand.ts
+++ b/src/features/line/commands/handleDcaCommand.ts
@@ -1,4 +1,5 @@
 import { dcaService } from "@/features/dca";
+import { formatDate, formatTHB } from "@/features/dca/utils/format";
 import { sendMessage } from "@/lib/utils/line-utils";
 import { dcaEventManager } from "@/lib/dca/event-manager";
 import {
@@ -11,22 +12,21 @@ import { createDcaSummaryFlexMessage } from "@/lib/line-utils/flex-messages";
 // Helpers
 // ========================
 
-const formatTHB = (n: number) =>
-  n.toLocaleString("th-TH", {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  });
-
-const formatDate = (date: Date) =>
-  new Intl.DateTimeFormat("th-TH", {
-    day: "2-digit",
-    month: "2-digit",
-    year: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-    timeZone: "Asia/Bangkok",
-    hour12: false,
-  }).format(date);
+const buildAddSuccessText = (
+  order: { orderId: string; round: number },
+  data: { coin: string; amountTHB: number; coinReceived: number; pricePerCoin: number; executedAt: Date },
+) =>
+  [
+    `✅ บันทึก Auto DCA สำเร็จ!`,
+    ``,
+    `📋 รหัสคำสั่ง: ${order.orderId}`,
+    `🪙 เหรียญ: ${data.coin}`,
+    `💰 เงินที่ใช้: ${formatTHB(data.amountTHB)} บาท`,
+    `💎 ได้รับ: ${data.coinReceived.toFixed(8)} ${data.coin}`,
+    `📈 ราคา: ${formatTHB(data.pricePerCoin)} บาท/${data.coin}`,
+    `🔄 รอบที่: ${order.round}`,
+    `📅 วันที่: ${formatDate(data.executedAt)}`,
+  ].join("\n");
 
 // ========================
 // Sub-handlers
@@ -67,9 +67,10 @@ const handleHelp = async (req: any) => {
         "  /dca list",
         "  /dca ประวัติ",
         "",
-        "🔹 ลบรายการ (ระบุเลขรอบ):",
-        "  /dca ลบ [รอบที่]",
-        "  /dca del [รอบที่]",
+        "🔹 ลบรายการ (รองรับลบหลายรอบพร้อมกัน):",
+        "  /dca ลบ 5",
+        "  /dca del 3 7 12",
+        "  /dca del 3,7,12",
         "─────────────────────",
         "📌 /dca help — แสดงคำสั่งนี้",
       ].join("\n"),
@@ -126,27 +127,8 @@ const handleAdd = async (req: any, args: string[]) => {
       });
 
       // 🎉 Emit SSE event เพื่อให้ web clients รับทราบ
-      dcaEventManager.emit({
-        type: "dca-order-created",
-        data: order,
-      });
-
-      await sendMessage(req, [
-        {
-          type: "text",
-          text: [
-            `✅ บันทึก Auto DCA สำเร็จ!`,
-            ``,
-            `📋 รหัสคำสั่ง: ${order.orderId}`,
-            `🪙 เหรียญ: ${parsed.coin}`,
-            `💰 เงินที่ใช้: ${formatTHB(parsed.amountTHB)} บาท`,
-            `💎 ได้รับ: ${parsed.coinReceived.toFixed(8)} ${parsed.coin}`,
-            `📈 ราคา: ${formatTHB(parsed.pricePerCoin)} บาท/${parsed.coin}`,
-            `🔄 รอบที่: ${order.round}`,
-            `📅 วันที่: ${formatDate(parsed.executedAt)}`,
-          ].join("\n"),
-        },
-      ]);
+      dcaEventManager.emit({ type: "dca-order-created", data: order });
+      await sendMessage(req, [{ type: "text", text: buildAddSuccessText(order, parsed) }]);
     } catch (err) {
       console.error("❌ DCA add (bitkub mode) error:", err);
       await sendMessage(req, [
@@ -232,27 +214,9 @@ const handleAdd = async (req: any, args: string[]) => {
       executedAt,
     });
 
-    // 🎉 Emit SSE event เพื่อให้ web clients รับทราบ
-    dcaEventManager.emit({
-      type: "dca-order-created",
-      data: order,
-    });
-
+    dcaEventManager.emit({ type: "dca-order-created", data: order });
     await sendMessage(req, [
-      {
-        type: "text",
-        text: [
-          `✅ บันทึก Auto DCA สำเร็จ!`,
-          ``,
-          `📋 รหัสคำสั่ง: ${order.orderId}`,
-          `🪙 เหรียญ: ${coin}`,
-          `💰 เงินที่ใช้: ${formatTHB(amountTHB)} บาท`,
-          `💎 ได้รับ: ${coinReceived.toFixed(8)} ${coin}`,
-          `📈 ราคา: ${formatTHB(pricePerCoin)} บาท/${coin}`,
-          `🔄 รอบที่: ${order.round}`,
-          `📅 วันที่: ${formatDate(executedAt)}`,
-        ].join("\n"),
-      },
+      { type: "text", text: buildAddSuccessText(order, { coin, amountTHB, coinReceived, pricePerCoin, executedAt }) },
     ]);
   } catch (err) {
     console.error("❌ DCA add error:", err);
@@ -268,8 +232,10 @@ const handleAdd = async (req: any, args: string[]) => {
  * /dca list | /dca ประวัติ
  */
 const handleList = async (req: any) => {
+  const userId = req.body?.events?.[0]?.source?.userId as string | undefined;
+
   try {
-    const result = await dcaService.listOrders({ page: 1, limit: 5 });
+    const result = await dcaService.listOrders({ page: 1, limit: 5, lineUserId: userId });
 
     if (result.orders.length === 0) {
       await sendMessage(req, [
@@ -309,65 +275,125 @@ const handleList = async (req: any) => {
 };
 
 /**
- * ลบรายการด้วยเลขรอบ
+ * ลบรายการด้วยเลขรอบ — รองรับหลายรอบพร้อมกัน
  *
- * /dca ลบ [round] | /dca del [round]
+ * รูปแบบที่รองรับ:
+ *   /dca ลบ 5           → ลบรอบเดียว
+ *   /dca del 3 7 12     → ลบหลายรอบ (คั่นด้วย space)
+ *   /dca del 3,7,12     → ลบหลายรอบ (คั่นด้วย comma)
+ *   /dca del 3, 7, 12   → ลบหลายรอบ (คั่นด้วย comma + space)
  */
 const handleDelete = async (req: any, args: string[]) => {
-  const roundStr = args[0];
-  if (!roundStr) {
+  const userId = req.body?.events?.[0]?.source?.userId as string | undefined;
+
+  if (!userId) {
+    await sendMessage(req, [
+      { type: "text", text: "❌ ไม่สามารถระบุตัวตนผู้ใช้ได้ กรุณาลองใหม่" },
+    ]);
+    return;
+  }
+
+  if (args.length === 0) {
     await sendMessage(req, [
       {
         type: "text",
-        text: "❌ ระบุเลขรอบที่ต้องการลบ\n\nตัวอย่าง: /dca ลบ 56",
+        text: [
+          "❌ ระบุเลขรอบที่ต้องการลบ",
+          "",
+          "ลบรอบเดียว:     /dca ลบ 5",
+          "ลบหลายรอบ:     /dca ลบ 3 7 12",
+          "ลบหลายรอบ:     /dca ลบ 3,7,12",
+        ].join("\n"),
       },
     ]);
     return;
   }
 
-  const round = parseInt(roundStr);
-  if (isNaN(round) || round <= 0) {
+  // ─── Parse round numbers — รองรับ space และ/หรือ comma ───────────────────
+  const rawTokens = args.join(" ").split(/[\s,]+/).filter(Boolean);
+  const validRounds: number[] = [];
+  const invalidTokens: string[] = [];
+
+  for (const token of rawTokens) {
+    const n = parseInt(token);
+    if (isNaN(n) || n <= 0) {
+      invalidTokens.push(token);
+    } else if (!validRounds.includes(n)) {
+      validRounds.push(n);
+    }
+  }
+
+  if (invalidTokens.length > 0) {
     await sendMessage(req, [
       {
         type: "text",
-        text: `❌ เลขรอบไม่ถูกต้อง: "${roundStr}"\n\nตัวอย่าง: /dca ลบ 56`,
+        text: `❌ เลขรอบไม่ถูกต้อง: ${invalidTokens.map((t) => `"${t}"`).join(", ")}\n\nใช้ตัวเลขจำนวนเต็มบวกเท่านั้น`,
       },
     ]);
     return;
   }
 
   try {
-    // ค้นหาด้วย round number
-    const found = await dcaService.findByRound(round);
-    if (!found) {
+    // ─── ค้นหาทุกรอบพร้อมกัน (1 query) ──────────────────────────────────
+    const found = await dcaService.findByRounds(validRounds, userId);
+    const foundRounds = found.map((o) => o.round);
+    const notFoundRounds = validRounds.filter((r) => !foundRounds.includes(r));
+
+    if (found.length === 0) {
+      const roundList = validRounds.join(", ");
       await sendMessage(req, [
-        { type: "text", text: `❌ ไม่พบรายการรอบที่ ${round}` },
+        {
+          type: "text",
+          text: `❌ ไม่พบรายการรอบที่ ${roundList} ของคุณ`,
+        },
       ]);
       return;
     }
 
-    await dcaService.deleteOrder(found.id);
+    // ─── ลบทั้งหมดพร้อมกัน ────────────────────────────────────────────────
+    await Promise.all(
+      found.map((order) => dcaService.deleteOrder(order.id)),
+    );
 
-    // 🗑️ Emit SSE event เพื่อให้ web clients รับทราบ
-    dcaEventManager.emit({
-      type: "dca-order-deleted",
-      data: { id: found.id, round: found.round },
-    });
+    // 🗑️ Emit SSE event ต่อ order
+    for (const order of found) {
+      dcaEventManager.emit({
+        type: "dca-order-deleted",
+        data: { id: order.id, round: order.round },
+      });
+    }
 
-    await sendMessage(req, [
-      {
-        type: "text",
-        text: [
-          `🗑️ ลบรายการสำเร็จ`,
-          ``,
-          `📋 รหัส: ${found.orderId}`,
-          `🪙 เหรียญ: ${found.coin}`,
-          `🔄 รอบที่: ${found.round}`,
-          `💰 เงิน: ${formatTHB(found.amountTHB)} บาท`,
-          `📅 วันที่: ${formatDate(new Date(found.executedAt))}`,
-        ].join("\n"),
-      },
-    ]);
+    // ─── สรุปผลลัพธ์ ──────────────────────────────────────────────────────
+    const lines: string[] = [];
+
+    if (found.length === 1) {
+      // ลบรอบเดียว — แสดงรายละเอียด
+      const o = found[0]!;
+      lines.push(
+        `🗑️ ลบรายการสำเร็จ`,
+        ``,
+        `📋 รหัส: ${o.orderId}`,
+        `🪙 เหรียญ: ${o.coin}`,
+        `🔄 รอบที่: ${o.round}`,
+        `💰 เงิน: ${formatTHB(o.amountTHB)} บาท`,
+        `📅 วันที่: ${formatDate(new Date(o.executedAt))}`,
+      );
+    } else {
+      // ลบหลายรอบ — แสดงสรุปรายการ
+      lines.push(`🗑️ ลบสำเร็จ ${found.length} รายการ`, `─────────────────────`);
+      for (const o of found) {
+        lines.push(
+          `รอบที่ ${o.round} • ${o.coin} • ${formatTHB(o.amountTHB)} บาท`,
+        );
+      }
+    }
+
+    // แจ้งรอบที่ไม่พบ (ถ้ามี)
+    if (notFoundRounds.length > 0) {
+      lines.push(``, `⚠️ ไม่พบรอบที่: ${notFoundRounds.join(", ")}`);
+    }
+
+    await sendMessage(req, [{ type: "text", text: lines.join("\n") }]);
   } catch (err) {
     console.error("❌ DCA delete error:", err);
     await sendMessage(req, [

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -39,6 +39,8 @@ import { Route as ApiHealthActivityActivitiesRouteImport } from './routes/api/he
 import { Route as ApiDebugLineOauthRouteImport } from './routes/api/debug/line-oauth'
 import { Route as ApiDcaSummaryRouteImport } from './routes/api/dca/summary'
 import { Route as ApiDcaStreamRouteImport } from './routes/api/dca/stream'
+import { Route as ApiDcaImportRouteImport } from './routes/api/dca/import'
+import { Route as ApiDcaExportRouteImport } from './routes/api/dca/export'
 import { Route as ApiDcaIdRouteImport } from './routes/api/dca/$id'
 import { Route as ApiCronImageCleanupRouteImport } from './routes/api/cron/image-cleanup'
 import { Route as ApiCronEnhancedCheckoutReminderRouteImport } from './routes/api/cron/enhanced-checkout-reminder'
@@ -202,6 +204,16 @@ const ApiDcaStreamRoute = ApiDcaStreamRouteImport.update({
   path: '/api/dca/stream',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiDcaImportRoute = ApiDcaImportRouteImport.update({
+  id: '/api/dca/import',
+  path: '/api/dca/import',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiDcaExportRoute = ApiDcaExportRouteImport.update({
+  id: '/api/dca/export',
+  path: '/api/dca/export',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiDcaIdRoute = ApiDcaIdRouteImport.update({
   id: '/api/dca/$id',
   path: '/api/dca/$id',
@@ -276,6 +288,8 @@ export interface FileRoutesByFullPath {
   '/api/cron/enhanced-checkout-reminder': typeof ApiCronEnhancedCheckoutReminderRoute
   '/api/cron/image-cleanup': typeof ApiCronImageCleanupRoute
   '/api/dca/$id': typeof ApiDcaIdRoute
+  '/api/dca/export': typeof ApiDcaExportRoute
+  '/api/dca/import': typeof ApiDcaImportRoute
   '/api/dca/stream': typeof ApiDcaStreamRoute
   '/api/dca/summary': typeof ApiDcaSummaryRoute
   '/api/debug/line-oauth': typeof ApiDebugLineOauthRoute
@@ -317,6 +331,8 @@ export interface FileRoutesByTo {
   '/api/cron/enhanced-checkout-reminder': typeof ApiCronEnhancedCheckoutReminderRoute
   '/api/cron/image-cleanup': typeof ApiCronImageCleanupRoute
   '/api/dca/$id': typeof ApiDcaIdRoute
+  '/api/dca/export': typeof ApiDcaExportRoute
+  '/api/dca/import': typeof ApiDcaImportRoute
   '/api/dca/stream': typeof ApiDcaStreamRoute
   '/api/dca/summary': typeof ApiDcaSummaryRoute
   '/api/debug/line-oauth': typeof ApiDebugLineOauthRoute
@@ -359,6 +375,8 @@ export interface FileRoutesById {
   '/api/cron/enhanced-checkout-reminder': typeof ApiCronEnhancedCheckoutReminderRoute
   '/api/cron/image-cleanup': typeof ApiCronImageCleanupRoute
   '/api/dca/$id': typeof ApiDcaIdRoute
+  '/api/dca/export': typeof ApiDcaExportRoute
+  '/api/dca/import': typeof ApiDcaImportRoute
   '/api/dca/stream': typeof ApiDcaStreamRoute
   '/api/dca/summary': typeof ApiDcaSummaryRoute
   '/api/debug/line-oauth': typeof ApiDebugLineOauthRoute
@@ -402,6 +420,8 @@ export interface FileRouteTypes {
     | '/api/cron/enhanced-checkout-reminder'
     | '/api/cron/image-cleanup'
     | '/api/dca/$id'
+    | '/api/dca/export'
+    | '/api/dca/import'
     | '/api/dca/stream'
     | '/api/dca/summary'
     | '/api/debug/line-oauth'
@@ -443,6 +463,8 @@ export interface FileRouteTypes {
     | '/api/cron/enhanced-checkout-reminder'
     | '/api/cron/image-cleanup'
     | '/api/dca/$id'
+    | '/api/dca/export'
+    | '/api/dca/import'
     | '/api/dca/stream'
     | '/api/dca/summary'
     | '/api/debug/line-oauth'
@@ -484,6 +506,8 @@ export interface FileRouteTypes {
     | '/api/cron/enhanced-checkout-reminder'
     | '/api/cron/image-cleanup'
     | '/api/dca/$id'
+    | '/api/dca/export'
+    | '/api/dca/import'
     | '/api/dca/stream'
     | '/api/dca/summary'
     | '/api/debug/line-oauth'
@@ -526,6 +550,8 @@ export interface RootRouteChildren {
   ApiCronEnhancedCheckoutReminderRoute: typeof ApiCronEnhancedCheckoutReminderRoute
   ApiCronImageCleanupRoute: typeof ApiCronImageCleanupRoute
   ApiDcaIdRoute: typeof ApiDcaIdRoute
+  ApiDcaExportRoute: typeof ApiDcaExportRoute
+  ApiDcaImportRoute: typeof ApiDcaImportRoute
   ApiDcaStreamRoute: typeof ApiDcaStreamRoute
   ApiDcaSummaryRoute: typeof ApiDcaSummaryRoute
   ApiDebugLineOauthRoute: typeof ApiDebugLineOauthRoute
@@ -752,6 +778,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiDcaStreamRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/dca/import': {
+      id: '/api/dca/import'
+      path: '/api/dca/import'
+      fullPath: '/api/dca/import'
+      preLoaderRoute: typeof ApiDcaImportRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/dca/export': {
+      id: '/api/dca/export'
+      path: '/api/dca/export'
+      fullPath: '/api/dca/export'
+      preLoaderRoute: typeof ApiDcaExportRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/dca/$id': {
       id: '/api/dca/$id'
       path: '/api/dca/$id'
@@ -868,6 +908,8 @@ const rootRouteChildren: RootRouteChildren = {
   ApiCronEnhancedCheckoutReminderRoute: ApiCronEnhancedCheckoutReminderRoute,
   ApiCronImageCleanupRoute: ApiCronImageCleanupRoute,
   ApiDcaIdRoute: ApiDcaIdRoute,
+  ApiDcaExportRoute: ApiDcaExportRoute,
+  ApiDcaImportRoute: ApiDcaImportRoute,
   ApiDcaStreamRoute: ApiDcaStreamRoute,
   ApiDcaSummaryRoute: ApiDcaSummaryRoute,
   ApiDebugLineOauthRoute: ApiDebugLineOauthRoute,

--- a/src/routes/api/dca/export.tsx
+++ b/src/routes/api/dca/export.tsx
@@ -1,0 +1,143 @@
+/**
+ * DCA Export API
+ * GET /api/dca/export?format=csv|json|xlsx
+ *
+ * ส่งออกประวัติคำสั่งซื้อ Auto DCA ทั้งหมดของ user ในรูปแบบที่เลือก
+ */
+import { createFileRoute } from "@tanstack/react-router";
+import * as XLSX from "xlsx";
+import { dcaService } from "@/features/dca";
+import type { DcaExportRow, ExportFormat } from "@/features/dca/types";
+import { getLineUserId } from "@/lib/auth";
+
+const EXPORT_COLUMNS: (keyof DcaExportRow)[] = [
+  "orderId", "executedAt", "coin", "amountTHB",
+  "coinReceived", "pricePerCoin", "round", "status", "note",
+];
+
+/** แปลง DcaOrder array เป็น flat row สำหรับ export */
+const toExportRows = (
+  orders: Awaited<ReturnType<typeof dcaService.listAllOrders>>,
+): DcaExportRow[] =>
+  orders.map((o) => ({
+    orderId: o.orderId,
+    executedAt: o.executedAt.toISOString(),
+    coin: o.coin,
+    amountTHB: o.amountTHB,
+    coinReceived: o.coinReceived,
+    pricePerCoin: o.pricePerCoin,
+    round: o.round,
+    status: o.status,
+    note: o.note ?? "",
+  }));
+
+/** สร้าง CSV string จาก rows */
+const buildCsv = (rows: DcaExportRow[]): string => {
+  const headerLine = EXPORT_COLUMNS.join(",");
+  const dataLines = rows.map((row) =>
+    EXPORT_COLUMNS.map((h) => {
+      const val = String(row[h]);
+      return val.includes(",") || val.includes('"')
+        ? `"${val.replace(/"/g, '""')}"`
+        : val;
+    }).join(","),
+  );
+  return [headerLine, ...dataLines].join("\n");
+};
+
+/** สร้าง Excel buffer จาก rows */
+const buildXlsx = (rows: DcaExportRow[]): Buffer => {
+  const ws = XLSX.utils.json_to_sheet(rows, { header: EXPORT_COLUMNS });
+
+  // ตั้ง column widths ให้อ่านง่าย
+  ws["!cols"] = [
+    { wch: 20 }, // orderId
+    { wch: 26 }, // executedAt
+    { wch: 8 },  // coin
+    { wch: 14 }, // amountTHB
+    { wch: 16 }, // coinReceived
+    { wch: 16 }, // pricePerCoin
+    { wch: 8 },  // round
+    { wch: 10 }, // status
+    { wch: 30 }, // note
+  ];
+
+  const wb = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(wb, ws, "DCA History");
+
+  return Buffer.from(XLSX.write(wb, { type: "buffer", bookType: "xlsx" }));
+};
+
+/**
+ * GET /api/dca/export?format=csv|json|xlsx
+ */
+export async function GET(request: Request) {
+  try {
+    const lineUserId = await getLineUserId(request);
+    if (!lineUserId) {
+      return Response.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const format = (searchParams.get("format") ?? "json") as ExportFormat;
+
+    if (!["csv", "json", "xlsx"].includes(format)) {
+      return Response.json(
+        { error: "format ต้องเป็น csv, json หรือ xlsx เท่านั้น" },
+        { status: 400 },
+      );
+    }
+
+    const orders = await dcaService.listAllOrders(lineUserId);
+    const rows = toExportRows(orders);
+    const timestamp = new Date()
+      .toISOString()
+      .slice(0, 19)
+      .replace(/[:T]/g, "-");
+    const filename = `dca-history-${timestamp}`;
+
+    if (format === "json") {
+      const body = JSON.stringify(rows, null, 2);
+      return new Response(body, {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json; charset=utf-8",
+          "Content-Disposition": `attachment; filename="${filename}.json"`,
+        },
+      });
+    }
+
+    if (format === "csv") {
+      const body = buildCsv(rows);
+      return new Response(body, {
+        status: 200,
+        headers: {
+          "Content-Type": "text/csv; charset=utf-8",
+          "Content-Disposition": `attachment; filename="${filename}.csv"`,
+        },
+      });
+    }
+
+    // xlsx
+    const buffer = buildXlsx(rows);
+    return new Response(new Uint8Array(buffer), {
+      status: 200,
+      headers: {
+        "Content-Type":
+          "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "Content-Disposition": `attachment; filename="${filename}.xlsx"`,
+      },
+    });
+  } catch (error) {
+    console.error("DCA export error:", error);
+    return Response.json({ error: "ไม่สามารถส่งออกข้อมูลได้" }, { status: 500 });
+  }
+}
+
+export const Route = createFileRoute("/api/dca/export")({
+  server: {
+    handlers: {
+      GET: ({ request }) => GET(request),
+    },
+  },
+});

--- a/src/routes/api/dca/import.tsx
+++ b/src/routes/api/dca/import.tsx
@@ -1,0 +1,285 @@
+/**
+ * DCA Import API
+ * POST /api/dca/import
+ *
+ * รับไฟล์ multipart/form-data (field name: "file")
+ * รองรับ .csv, .json, .xlsx
+ *
+ * Response: { imported, skipped, errors }
+ */
+import { createFileRoute } from "@tanstack/react-router";
+import * as XLSX from "xlsx";
+import { z } from "zod";
+import { dcaService } from "@/features/dca";
+import type { ExportFormat, ImportResult } from "@/features/dca/types";
+import { getLineUserId } from "@/lib/auth";
+
+const VALID_FORMATS: ExportFormat[] = ["csv", "json", "xlsx"];
+
+/** unique key สำหรับตรวจ duplicate: coin + executedAt ISO */
+const dupKey = (coin: string, executedAt: Date) =>
+  `${coin}|${executedAt.toISOString()}`;
+
+/** Zod validator สำหรับตัวเลข positive (รองรับ string และ number จาก CSV/Excel) */
+const positiveFloat = (fieldName: string) =>
+  z
+    .union([z.string(), z.number()])
+    .transform((v) => parseFloat(String(v)))
+    .refine((v) => !isNaN(v) && v > 0, `${fieldName} ต้องมากกว่า 0`);
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * แปลง Excel date serial number → ISO string
+ * Excel เก็บวันที่เป็นตัวเลข เช่น 45678 = วันที่ xx/xx/xxxx
+ */
+const excelSerialToIso = (serial: number): string => {
+  // Excel epoch = 1 Jan 1900, แต่มี bug ที่นับ 1900 ว่าเป็น leap year
+  // จึงต้องลบ 25569 (จำนวนวันจาก 1900-01-01 ถึง 1970-01-01) และ offset 1 วัน
+  const ms = (serial - 25569) * 86400 * 1000;
+  return new Date(ms).toISOString();
+};
+
+/**
+ * Normalize executedAt ให้เป็น ISO string ไม่ว่าจะมาจาก:
+ * - ISO string "2026-04-11T08:00:14.663+07:00"
+ * - Simple date string "2026-04-11"
+ * - Excel serial number 45678
+ */
+const normalizeExecutedAt = (raw: unknown): string => {
+  if (typeof raw === "number") {
+    return excelSerialToIso(raw);
+  }
+  return String(raw ?? "");
+};
+
+// ─── Validation schema สำหรับแต่ละแถวของข้อมูล ────────────────────────────────
+
+const importRowSchema = z.object({
+  orderId: z.string().optional(),
+  executedAt: z
+    .union([z.string(), z.number()])
+    .transform(normalizeExecutedAt)
+    .refine((v) => v.length > 0 && !isNaN(new Date(v).getTime()), "executedAt ไม่ใช่วันที่ที่ถูกต้อง"),
+  coin: z.string().min(1).max(20).transform((v) => v.toUpperCase()),
+  amountTHB: positiveFloat("amountTHB"),
+  coinReceived: positiveFloat("coinReceived"),
+  pricePerCoin: positiveFloat("pricePerCoin"),
+  status: z.enum(["SUCCESS", "FAILED", "PENDING"]).optional().default("SUCCESS"),
+  note: z.string().optional().default(""),
+});
+
+// ─── Parsers ──────────────────────────────────────────────────────────────────
+
+/** Parse JSON file → raw row array */
+const parseJson = (text: string): unknown[] => {
+  const parsed = JSON.parse(text);
+  if (!Array.isArray(parsed)) throw new Error("JSON ต้องเป็น array ของ objects");
+  return parsed;
+};
+
+/** Parse CSV text → raw row array */
+const parseCsv = (text: string): Record<string, string>[] => {
+  // filter empty lines ก่อน (trailing newlines, blank lines กลางไฟล์)
+  const lines = text.trim().split(/\r?\n/).filter((l) => l.trim().length > 0);
+  if (lines.length < 2) throw new Error("CSV ต้องมีอย่างน้อย 1 แถวข้อมูล (นอกจาก header)");
+
+  const headers = lines[0]!.split(",").map((h) => h.trim().replace(/^"|"$/g, ""));
+
+  return lines.slice(1).map((line, idx) => {
+    // Simple CSV parse ที่รองรับ quoted fields
+    const values: string[] = [];
+    let current = "";
+    let inQuote = false;
+
+    for (let i = 0; i < line.length; i++) {
+      const ch = line[i];
+      if (ch === '"') {
+        if (inQuote && line[i + 1] === '"') {
+          current += '"';
+          i++;
+        } else {
+          inQuote = !inQuote;
+        }
+      } else if (ch === "," && !inQuote) {
+        values.push(current);
+        current = "";
+      } else {
+        current += ch;
+      }
+    }
+    values.push(current);
+
+    if (values.length !== headers.length) {
+      throw new Error(`แถวที่ ${idx + 2}: จำนวน columns ไม่ตรงกับ header`);
+    }
+
+    return Object.fromEntries(headers.map((h, i) => [h, values[i] ?? ""]));
+  });
+};
+
+/** Parse XLSX buffer → raw row array */
+const parseXlsx = (buffer: ArrayBuffer): unknown[] => {
+  const wb = XLSX.read(buffer, { type: "array" });
+  const sheetName = wb.SheetNames[0];
+  if (!sheetName) throw new Error("ไม่พบ sheet ใน Excel file");
+  const ws = wb.Sheets[sheetName]!;
+  return XLSX.utils.sheet_to_json(ws, { defval: "" });
+};
+
+// ─── Main Handler ─────────────────────────────────────────────────────────────
+
+export async function POST(request: Request) {
+  try {
+    const lineUserId = await getLineUserId(request);
+    if (!lineUserId) {
+      return Response.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const contentType = request.headers.get("content-type") ?? "";
+    if (!contentType.includes("multipart/form-data")) {
+      return Response.json(
+        { error: "Content-Type ต้องเป็น multipart/form-data" },
+        { status: 400 },
+      );
+    }
+
+    const formData = await request.formData();
+    const file = formData.get("file");
+
+    if (!file || !(file instanceof File)) {
+      return Response.json({ error: "ไม่พบไฟล์ (field name: file)" }, { status: 400 });
+    }
+
+    const fileName = file.name.toLowerCase();
+    const ext = fileName.split(".").pop();
+
+    if (!VALID_FORMATS.includes((ext ?? "") as ExportFormat)) {
+      return Response.json(
+        { error: "รองรับเฉพาะไฟล์ .csv, .json, .xlsx เท่านั้น" },
+        { status: 400 },
+      );
+    }
+
+    // ─── Parse raw rows ───────────────────────────────────────────────────
+    let rawRows: unknown[];
+
+    if (ext === "json") {
+      const text = await file.text();
+      rawRows = parseJson(text);
+    } else if (ext === "csv") {
+      const text = await file.text();
+      rawRows = parseCsv(text);
+    } else {
+      // xlsx
+      const arrayBuffer = await file.arrayBuffer();
+      rawRows = parseXlsx(arrayBuffer);
+    }
+
+    // ─── Step 1: Validate rows ────────────────────────────────────────────
+    const result: ImportResult = { imported: 0, skipped: 0, errors: [] };
+
+    type ValidRow = {
+      index: number;
+      data: z.infer<typeof importRowSchema>;
+      executedAt: Date;
+    };
+
+    const validRows: ValidRow[] = [];
+
+    for (let i = 0; i < rawRows.length; i++) {
+      const rowLabel = `แถวที่ ${i + 1}`;
+      const parsed = importRowSchema.safeParse(rawRows[i]);
+
+      if (!parsed.success) {
+        const msg = parsed.error.issues.map((e: { message: string }) => e.message).join(", ");
+        result.errors.push(`${rowLabel}: ${msg}`);
+        result.skipped++;
+        continue;
+      }
+
+      // executedAt ผ่าน schema refine มาแล้ว แน่ใจว่า valid
+      const executedAt = new Date(parsed.data.executedAt);
+      validRows.push({ index: i, data: parsed.data, executedAt });
+    }
+
+    // ─── Step 2: ตรวจซ้ำภายในไฟล์เดียวกัน ───────────────────────────────
+    const seenInFile = new Set<string>();
+    const uniqueInFile: ValidRow[] = [];
+
+    for (const row of validRows) {
+      const key = dupKey(row.data.coin, row.executedAt);
+      if (seenInFile.has(key)) {
+        result.errors.push(
+          `แถวที่ ${row.index + 1}: ซ้ำกับแถวอื่นในไฟล์เดียวกัน (${row.data.coin} @ ${row.executedAt.toISOString()})`,
+        );
+        result.skipped++;
+      } else {
+        seenInFile.add(key);
+        uniqueInFile.push(row);
+      }
+    }
+
+    // ─── Step 3: ตรวจซ้ำกับ DB (1 query) ────────────────────────────────
+    const existingInDb = await dcaService.findDuplicates(
+      lineUserId,
+      uniqueInFile.map((r) => ({ coin: r.data.coin, executedAt: r.executedAt })),
+    );
+
+    const dupInDbKeys = new Set(existingInDb.map((d) => dupKey(d.coin, d.executedAt)));
+    const rowsToInsert: ValidRow[] = [];
+
+    for (const row of uniqueInFile) {
+      if (dupInDbKeys.has(dupKey(row.data.coin, row.executedAt))) {
+        result.errors.push(
+          `แถวที่ ${row.index + 1}: ซ้ำกับข้อมูลที่มีอยู่แล้ว (${row.data.coin} @ ${row.executedAt.toISOString()})`,
+        );
+        result.skipped++;
+      } else {
+        rowsToInsert.push(row);
+      }
+    }
+
+    // ─── Step 4: Create orders แบบ parallel ──────────────────────────────
+    const createResults = await Promise.allSettled(
+      rowsToInsert.map(({ data, executedAt }) =>
+        dcaService.createOrder({
+          lineUserId,
+          coin: data.coin,
+          amountTHB: data.amountTHB,
+          coinReceived: data.coinReceived,
+          pricePerCoin: data.pricePerCoin,
+          executedAt,
+          status: data.status,
+          note: data.note || undefined,
+        }),
+      ),
+    );
+
+    for (let i = 0; i < createResults.length; i++) {
+      const res = createResults[i]!;
+      const rowLabel = `แถวที่ ${rowsToInsert[i]!.index + 1}`;
+      if (res.status === "fulfilled") {
+        result.imported++;
+      } else {
+        const msg = res.reason instanceof Error ? res.reason.message : "unknown error";
+        result.errors.push(`${rowLabel}: บันทึกไม่สำเร็จ — ${msg}`);
+        result.skipped++;
+      }
+    }
+
+    return Response.json(result, { status: 200 });
+  } catch (error) {
+    console.error("DCA import error:", error);
+    const msg = error instanceof Error ? error.message : "ไม่สามารถนำเข้าข้อมูลได้";
+    return Response.json({ error: msg }, { status: 500 });
+  }
+}
+
+export const Route = createFileRoute("/api/dca/import")({
+  server: {
+    handlers: {
+      POST: ({ request }) => POST(request),
+    },
+  },
+});

--- a/src/routes/dca-history.tsx
+++ b/src/routes/dca-history.tsx
@@ -2,10 +2,12 @@
 
 import { createFileRoute } from "@tanstack/react-router";
 import { useCallback, useState } from "react";
-import { Bitcoin, Plus, RefreshCw } from "lucide-react";
+import { Bitcoin, Plus, RefreshCw, Upload } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { AddDcaForm } from "@/features/dca/components/AddDcaForm";
+import { DcaExportButtons } from "@/features/dca/components/DcaExportButtons";
 import { DcaHistoryTable } from "@/features/dca/components/DcaHistoryTable";
+import { DcaImportModal } from "@/features/dca/components/DcaImportModal";
 import { DcaInfoBox } from "@/features/dca/components/DcaInfoBox";
 import { DcaSummaryCards } from "@/features/dca/components/DcaSummaryCards";
 import { useDcaHistoryData } from "@/features/dca/hooks/useDcaHistoryData";
@@ -14,6 +16,7 @@ import { useDcaRealtimeUpdates } from "@/features/dca/hooks/useDcaRealtimeUpdate
 function DcaHistoryPage() {
   const [page, setPage] = useState(1);
   const [showAddForm, setShowAddForm] = useState(false);
+  const [showImportModal, setShowImportModal] = useState(false);
   const limit = 10;
 
   const { ordersData, summaryData, isLoading, error, refetchAll } =
@@ -21,13 +24,11 @@ function DcaHistoryPage() {
 
   useDcaRealtimeUpdates({ onUpdate: refetchAll });
 
-  const handleAddSuccess = useCallback(() => {
+  const handleDataMutated = useCallback(() => {
     setPage(1);
-
     const channel = new BroadcastChannel("dca-updates");
     channel.postMessage({ type: "update" });
     channel.close();
-
     refetchAll();
   }, [refetchAll]);
 
@@ -39,7 +40,7 @@ function DcaHistoryPage() {
       >
         <div
           id="dca-history-header"
-          className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between"
+          className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between"
         >
           <div id="dca-history-heading-group" className="space-y-1">
             <h1
@@ -53,7 +54,30 @@ function DcaHistoryPage() {
               บันทึกประวัติการลงทุนแบบ Dollar Cost Averaging สำหรับ Bitcoin
             </p>
           </div>
-          <div id="dca-history-actions" className="flex gap-2">
+
+          <div
+            id="dca-history-actions"
+            className="flex flex-wrap items-center gap-2"
+          >
+            {/* Export buttons */}
+            <DcaExportButtons disabled={isLoading || !ordersData?.total} />
+
+            {/* Divider */}
+            <div className="bg-border h-6 w-px" aria-hidden />
+
+            {/* Import button */}
+            <Button
+              id="dca-history-import-button"
+              variant="outline"
+              size="sm"
+              onClick={() => setShowImportModal(true)}
+              className="gap-2"
+            >
+              <Upload className="h-4 w-4" />
+              นำเข้า
+            </Button>
+
+            {/* Refresh button */}
             <Button
               id="dca-history-refresh-button"
               variant="outline"
@@ -67,6 +91,8 @@ function DcaHistoryPage() {
               />
               รีเฟรช
             </Button>
+
+            {/* Add button */}
             <Button
               id="dca-history-add-button"
               size="sm"
@@ -95,7 +121,14 @@ function DcaHistoryPage() {
       {showAddForm && (
         <AddDcaForm
           onClose={() => setShowAddForm(false)}
-          onSuccess={handleAddSuccess}
+          onSuccess={handleDataMutated}
+        />
+      )}
+
+      {showImportModal && (
+        <DcaImportModal
+          onClose={() => setShowImportModal(false)}
+          onSuccess={handleDataMutated}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary

- Add `GET /api/dca/export?format=csv|json|xlsx` endpoint to export all DCA order history for the authenticated user
- Add `POST /api/dca/import` endpoint to import DCA history from CSV, JSON, or Excel files with duplicate detection via a new `@@unique([lineUserId, coin, executedAt])` constraint
- Add `DcaExportButtons` component with per-format loading state and browser-triggered file download
- Add `DcaImportModal` component with drag-and-drop file selection, upload progress, and per-row error reporting
- Upgrade `/dca ลบ` / `/dca del` LINE command to support multi-round deletion (space- or comma-separated), batching finds and deletes into single queries
- Fix `getNextRound` and `findByRound` to scope round numbers per `lineUserId`, preventing cross-user round collisions
- Extract `formatTHB` / `formatDate` helpers into shared util and deduplicate inline copies from `handleDcaCommand.ts`
- Add `xlsx` (SheetJS) dependency for Excel read/write support

## Testing

- Export CSV: visit DCA history page, click "CSV" button, verify file downloads with correct headers and data
- Export JSON: click "JSON" button, verify well-formed JSON array with all orders
- Export Excel: click "Excel" button, open downloaded `.xlsx` and verify column widths and sheet name "DCA History"
- Export auth: call `GET /api/dca/export` without a session, expect `401 Unauthorized`
- Import CSV: upload a valid CSV file via the import modal, verify success count and data appears in history
- Import JSON: upload a valid JSON array, verify records are inserted
- Import Excel: upload a `.xlsx` file, verify records are inserted
- Import duplicates: import the same file twice, verify second import reports skipped rows and no duplicates in DB
- Import invalid file: upload a `.txt` file, verify modal shows extension error without submitting
- Import missing columns: upload a CSV missing required columns, verify per-row errors are shown in result step
- Multi-round delete (space): send `/dca del 3 7 12` in LINE, verify all three rounds are deleted and summary lists each
- Multi-round delete (comma): send `/dca del 3,7,12`, verify same behavior
- Multi-round delete partial: include a non-existent round, verify found rounds are deleted and warning lists missing rounds
- Single-round delete: send `/dca ลบ 5`, verify detailed single-order confirmation message is returned
- Cross-user isolation: confirm `findByRound`, `findByRounds`, and `getNextRound` all scope to the requesting user's `lineUserId`