### PR TITLE
feat: add LINE approval guard and protected route enforcement

### DIFF
--- a/src/components/auth/LineApprovalGuard.tsx
+++ b/src/components/auth/LineApprovalGuard.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+/**
+ * LineApprovalGuard Component
+ * ป้องกันไม่ให้ผู้ใช้ที่ยังไม่ได้อนุมัติเข้าถึง content
+ *
+ * Usage:
+ * ```tsx
+ * <LineApprovalGuard>
+ *   <YourPageContent />
+ * </LineApprovalGuard>
+ * ```
+ *
+ * หรือใช้แบบ inline:
+ * ```tsx
+ * <LineApprovalGuard>
+ *   {children}
+ * </LineApprovalGuard>
+ * ```
+ */
+import { useEffect } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { useLineApproval } from "@/hooks/useLineApproval";
+
+export function LineApprovalGuard({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const navigate = useNavigate();
+  const { isLoading, needsApproval } = useLineApproval();
+
+  useEffect(() => {
+    // Redirect ถ้ายังไม่ได้อนุมัติ
+    if (!isLoading && needsApproval) {
+      void navigate({ to: "/pending-approval", replace: true });
+    }
+  }, [isLoading, needsApproval, navigate]);
+
+  // Show loading state
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <p className="text-muted-foreground text-lg">กำลังตรวจสอบ...</p>
+      </div>
+    );
+  }
+
+  // แสดง content ถ้าผ่าน
+  return <>{children}</>;
+}
+
+/**
+ * HOC pattern สำหรับใช้กับ existing components
+ * Usage:
+ * ```tsx
+ * const ProtectedPage = withLineApproval(() => <DashboardPage />);
+ * ```
+ */
+export function withLineApproval<P extends object>(
+  Component: React.ComponentType<P>,
+) {
+  return function WithLineApproval(props: P) {
+    return (
+      <LineApprovalGuard>
+        <Component {...props} />
+      </LineApprovalGuard>
+    );
+  };
+}

--- a/src/components/auth/PendingApprovalModal.tsx
+++ b/src/components/auth/PendingApprovalModal.tsx
@@ -1,0 +1,106 @@
+/**
+ * PendingApprovalModal Component
+ * Modal ที่ block การใช้งานเมื่อ LINE user ยังไม่ได้รับอนุมัติ
+ *
+ * Usage:
+ * ```tsx
+ * import { PendingApprovalModal } from "@/components/auth/PendingApprovalModal";
+ *
+ * function Dashboard() {
+ *   const { needsApproval } = useLineApproval();
+ *
+ *   return (
+ *     <>
+ *       <PendingApprovalModal open={needsApproval} />
+ *       <DashboardContent />
+ *     </>
+ *   );
+ * }
+ * ```
+ */
+import { Clock, MessageSquare, ShieldCheck, X } from "lucide-react";
+
+interface PendingApprovalModalProps {
+  open: boolean;
+  onClose?: () => void;
+}
+
+export function PendingApprovalModal({ open, onClose }: PendingApprovalModalProps) {
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      {/* Backdrop */}
+      <div className="fixed inset-0 bg-black/60 backdrop-blur-sm" />
+
+      {/* Modal Content */}
+      <div className="relative bg-card max-w-md w-full rounded-xl border shadow-2xl p-8 text-center animate-in fade-in zoom-in duration-200">
+        {/* Icon */}
+        <div className="mx-auto mb-6 flex h-20 w-20 items-center justify-center rounded-full bg-amber-100 text-amber-600 dark:bg-amber-900/30">
+          <Clock className="h-10 w-10 animate-pulse" />
+        </div>
+
+        {/* Heading */}
+        <h2 className="text-foreground mb-3 text-2xl font-bold">
+          รอการอนุมัติ
+        </h2>
+
+        {/* Message */}
+        <p className="text-muted-foreground mb-6 text-sm leading-relaxed">
+          บัญชี LINE ของคุณยังไม่ได้รับการอนุมัติให้ใช้งาน
+          <br />
+          กรุณารอสัญญาณ admin เพื่อขออนุมัติใช้งาน
+        </p>
+
+        {/* Info */}
+        <div className="border-border bg-muted/50 mb-8 rounded-lg border p-4 text-left">
+          <div className="mb-3 flex items-start gap-3">
+            <MessageSquare className="text-primary h-5 w-5 shrink-0" />
+            <div>
+              <p className="text-foreground font-medium text-sm">
+                อะไรบ้างที่ต้องการอนุมัติ?
+              </p>
+              <p className="text-muted-foreground mt-1 text-xs">
+                LINE Messaging API: ส่งคำสั่งผ่าน LINE Bot
+              </p>
+            </div>
+          </div>
+          <div className="flex items-start gap-3">
+            <ShieldCheck className="text-primary h-5 w-5 shrink-0" />
+            <div>
+              <p className="text-foreground font-medium text-sm">
+                ผู้อนุมัติบางคน?
+              </p>
+              <p className="text-muted-foreground mt-1 text-xs">
+                Admin จะตรวจสอบและอนุมัติคำของของคุณ
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="flex flex-col gap-3">
+          <a
+            href="/"
+            className="bg-primary text-primary-foreground inline-flex w-full items-center justify-center rounded-md px-4 py-2 text-sm font-medium transition-opacity hover:opacity-90"
+          >
+            กลับหน้าหลัก
+          </a>
+          <a
+            href="/logout"
+            className="text-muted-foreground inline-flex w-full items-center justify-center rounded-md px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
+          >
+            ออกจากระบบ
+          </a>
+        </div>
+
+        {/* Help text */}
+        <p className="text-muted-foreground mt-6 text-xs">
+          หากมีข้อสงสัย หรือต้องการติดต่อ admin โปรดติดต่อทีมงาน
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/features/crypto/services/crypto-currency.ts
+++ b/src/features/crypto/services/crypto-currency.ts
@@ -45,7 +45,8 @@ const isUrlSafeToFetch = (urlString: string): boolean => {
       hostname.startsWith("10.") ||
       hostname.startsWith("172.") ||
       hostname.endsWith(".local") ||
-      hostname.includes("internal")
+      hostname === "internal" ||
+      hostname.endsWith(".internal")
     ) {
       return false;
     }

--- a/src/features/dca/services/dca.service.ts
+++ b/src/features/dca/services/dca.service.ts
@@ -9,6 +9,9 @@ import type {
 /**
  * สร้าง orderId รูปแบบ {COIN}DCA{padded 10 digit}
  * เช่น BTCDCA0000004700
+ *
+ * note: orderId อาจจะไม่ unique ระดับระบบ (ระหว่าง users ได้)
+ * แต่ id (ObjectId) จะเป็น unique ตัวจริง
  */
 const generateOrderId = (coin: string, round: number): string => {
   const paddedRound = round.toString().padStart(10, "0");
@@ -16,15 +19,18 @@ const generateOrderId = (coin: string, round: number): string => {
 };
 
 /**
- * ดึงรอบถัดไปสำหรับเหรียญที่ระบุ (นับจาก DCA orders ที่มีอยู่แล้ว)
+ * ดึงรอบถัดไปสำหรับเหรียญและ user ที่ระบุ
+ * คำนวณจากจำนวนรายการทั้งหมดของเหรียญและ user นั้น รองรับการ import ข้อมูลย้อนหลัง
  */
-const getNextRound = async (coin: string): Promise<number> => {
-  const latest = await db.dcaOrder.findFirst({
-    where: { coin: coin.toUpperCase() },
-    orderBy: { round: "desc" },
-    select: { round: true },
+const getNextRound = async (coin: string, lineUserId: string): Promise<number> => {
+  // นับจำนวนรายการทั้งหมดของเหรียญและ user นั้น เพื่อรองรับการ import ข้อมูลย้อนหลัง
+  const count = await db.dcaOrder.count({
+    where: {
+      coin: coin.toUpperCase(),
+      lineUserId,
+    },
   });
-  return (latest?.round ?? 0) + 1;
+  return count + 1;
 };
 
 /**
@@ -32,7 +38,7 @@ const getNextRound = async (coin: string): Promise<number> => {
  */
 const createOrder = async (input: CreateDcaOrderInput) => {
   const coin = input.coin.toUpperCase();
-  const round = await getNextRound(coin);
+  const round = await getNextRound(coin, input.lineUserId);
   const orderId = generateOrderId(coin, round);
 
   return db.dcaOrder.create({

--- a/src/features/dca/services/dca.service.ts
+++ b/src/features/dca/services/dca.service.ts
@@ -19,18 +19,15 @@ const generateOrderId = (coin: string, round: number): string => {
 };
 
 /**
- * ดึงรอบถัดไปสำหรับเหรียญและ user ที่ระบุ
- * คำนวณจากจำนวนรายการทั้งหมดของเหรียญและ user นั้น รองรับการ import ข้อมูลย้อนหลัง
+ * ดึงรอบถัดไปสำหรับ user และเหรียญที่ระบุ (นับแยกตาม lineUserId)
  */
 const getNextRound = async (coin: string, lineUserId: string): Promise<number> => {
-  // นับจำนวนรายการทั้งหมดของเหรียญและ user นั้น เพื่อรองรับการ import ข้อมูลย้อนหลัง
-  const count = await db.dcaOrder.count({
-    where: {
-      coin: coin.toUpperCase(),
-      lineUserId,
-    },
+  const latest = await db.dcaOrder.findFirst({
+    where: { coin: coin.toUpperCase(), lineUserId },
+    orderBy: { round: "desc" },
+    select: { round: true },
   });
-  return count + 1;
+  return (latest?.round ?? 0) + 1;
 };
 
 /**

--- a/src/features/line/commands/handleApprovalCheck.ts
+++ b/src/features/line/commands/handleApprovalCheck.ts
@@ -7,6 +7,7 @@
  * - false → ไม่ผ่าน (new/pending/rejected) ได้ส่ง reply ไปให้ user แล้ว
  */
 import { approvalService } from "../services/approval.service";
+import { APPROVAL_CHECK_RESULT } from "../types/approval.types";
 
 /**
  * ดึงโปรไฟล์ LINE user จาก Messaging API
@@ -56,21 +57,21 @@ export const handleApprovalCheck = async (
   });
 
   switch (status) {
-    case "APPROVED":
+    case APPROVAL_CHECK_RESULT.APPROVED:
       // ✅ ผ่าน — ดำเนินการต่อ
       return true;
 
-    case "NEW":
+    case APPROVAL_CHECK_RESULT.NEW:
       // 🆕 สร้าง request ใหม่ — แจ้งให้รอ
       await approvalService.sendPendingNewMessage(userId);
       return false;
 
-    case "PENDING":
+    case APPROVAL_CHECK_RESULT.PENDING:
       // ⏳ ยังรออยู่ — แจ้งซ้ำ
       await approvalService.sendPendingMessage(userId);
       return false;
 
-    case "REJECTED":
+    case APPROVAL_CHECK_RESULT.REJECTED:
       // ❌ ถูกปฏิเสธ — แจ้งปฏิเสธ (ไม่ส่ง reason ซ้ำ เพราะส่งตอน reject ไปแล้ว)
       await approvalService.sendRejectedMessage(userId);
       return false;

--- a/src/features/line/constants/approval.constants.ts
+++ b/src/features/line/constants/approval.constants.ts
@@ -1,0 +1,28 @@
+/**
+ * LINE Approval Constants
+ * Constants สำหรับ ApprovalStatus enum จาก Prisma schema
+ *
+ * ค่าเหล่านี้ต้องตรงกับ enum ApprovalStatus ใน prisma/schema.prisma:
+ * enum ApprovalStatus {
+ *   PENDING
+ *   APPROVED
+ *   REJECTED
+ * }
+ */
+
+/**
+ * Constants สำหรับ ApprovalStatus enum values
+ * ใช้ใน repository layer และ database operations
+ */
+export const APPROVAL_STATUS = {
+  PENDING: "PENDING" as const,
+  APPROVED: "APPROVED" as const,
+  REJECTED: "REJECTED" as const,
+} as const;
+
+/**
+ * Type สำหรับ ApprovalStatus enum values
+ * ใช้สำหรับ type safety เมื่อต้องการ type แทนการใช้ import จาก @prisma/client
+ */
+export type ApprovalStatusValue =
+  (typeof APPROVAL_STATUS)[keyof typeof APPROVAL_STATUS];

--- a/src/features/line/services/approval.repository.ts
+++ b/src/features/line/services/approval.repository.ts
@@ -4,6 +4,7 @@
  */
 import { db } from "@/lib/database/db";
 import type { ApprovalStatus, LineApprovalRequest } from "@prisma/client";
+import { APPROVAL_STATUS } from "../constants/approval.constants";
 
 export interface CreateApprovalInput {
   lineUserId: string;
@@ -27,6 +28,7 @@ export interface UpdateApprovalInput {
   notifiedAt?: Date;
   displayName?: string;
   pictureUrl?: string;
+  statusMessage?: string;
 }
 
 export interface ApprovalListParams {
@@ -113,7 +115,7 @@ const create = async (
       pictureUrl: input.pictureUrl,
       statusMessage: input.statusMessage,
       reason: input.reason,
-      status: input.status ?? "PENDING",
+      status: input.status ?? APPROVAL_STATUS.PENDING,
       approvedBy: input.approvedBy,
       approvedAt: input.approvedAt,
       rejectReason: input.rejectReason,
@@ -293,9 +295,15 @@ const markNotified = async (id: string): Promise<LineApprovalRequest> => {
  */
 const getStats = async () => {
   const [pending, approved, rejected, accountsTotal] = await Promise.all([
-    db.lineApprovalRequest.count({ where: { status: "PENDING" } }),
-    db.lineApprovalRequest.count({ where: { status: "APPROVED" } }),
-    db.lineApprovalRequest.count({ where: { status: "REJECTED" } }),
+    db.lineApprovalRequest.count({
+      where: { status: APPROVAL_STATUS.PENDING },
+    }),
+    db.lineApprovalRequest.count({
+      where: { status: APPROVAL_STATUS.APPROVED },
+    }),
+    db.lineApprovalRequest.count({
+      where: { status: APPROVAL_STATUS.REJECTED },
+    }),
     db.account.count({ where: { provider: "line" } }),
   ]);
 

--- a/src/features/line/services/approval.service.ts
+++ b/src/features/line/services/approval.service.ts
@@ -337,6 +337,25 @@ const setUserAdmin = async (params: {
 };
 
 /**
+ * Admin: ปลดล็อคผู้ใช้ที่ถูกปฏิเสธ เพื่อให้ขออนุมัติใหม่ได้
+ * - เปลี่ยนสถานะจาก REJECTED → PENDING
+ * - ล้าง rejectReason
+ */
+const unlockRejectedUser = async (
+  id: string,
+  adminUserId: string,
+): Promise<LineApprovalRequest> => {
+  const record = await approvalRepository.update(id, {
+    status: APPROVAL_CHECK_RESULT.PENDING,
+    rejectReason: null,
+    approvedBy: adminUserId,
+    approvedAt: new Date(),
+  });
+
+  return record;
+};
+
+/**
  * ดึง stats สำหรับ dashboard
  */
 const getStats = () => approvalRepository.getStats();
@@ -349,6 +368,7 @@ export const approvalService = {
   approveUser,
   rejectUser,
   rejectLineUser,
+  unlockRejectedUser,
   getApprovalList,
   getAccountApprovalList,
   setUserAdmin,

--- a/src/features/line/services/approval.service.ts
+++ b/src/features/line/services/approval.service.ts
@@ -8,6 +8,14 @@ import { sendPushMessage } from "@/lib/utils/line-push";
 import { approvalBubbleTemplate } from "@/lib/validation/line-approval";
 import { flexMessage } from "@/lib/utils/line-message-utils";
 import type { ApprovalStatus, LineApprovalRequest } from "@prisma/client";
+import type { ApprovalCheckResult } from "../types/approval.types";
+import { APPROVAL_CHECK_RESULT } from "../types/approval.types";
+
+/**
+ * Constant สำหรับระบุว่าการอนุมัตินี้มาจากระบบ (auto-approval)
+ * ใช้กรณี admin ใน ADMIN_LINE_USER_IDS whitelist
+ */
+const ADMIN_WHITELIST_AUTO_APPROVER = "WHITELIST_AUTO";
 
 export interface LineUserProfile {
   userId: string;
@@ -48,7 +56,28 @@ export interface AccountApprovalItem {
  */
 const checkApprovalStatus = async (
   userProfile: LineUserProfile,
-): Promise<"APPROVED" | "PENDING" | "REJECTED" | "NEW"> => {
+): Promise<ApprovalCheckResult> => {
+  // 🔐 Admin whitelist check — ผู้อยู่ใน ADMIN_LINE_USER_IDS ได้รับอนุมัติอัตโนมัติ
+  if (isAdminLineUser(userProfile.userId)) {
+    const existing = await approvalRepository.findByLineUserId(
+      userProfile.userId,
+    );
+
+    // ถ้ายังไม่มี record หรือสถานะไม่ใช่ APPROVED → สร้าง/อัปเดตเป็น APPROVED
+    if (!existing || existing.status !== APPROVAL_CHECK_RESULT.APPROVED) {
+      await approvalRepository.upsertByLineUserId(userProfile.userId, {
+        status: APPROVAL_CHECK_RESULT.APPROVED,
+        displayName: userProfile.displayName,
+        pictureUrl: userProfile.pictureUrl,
+        statusMessage: userProfile.statusMessage,
+        approvedBy: ADMIN_WHITELIST_AUTO_APPROVER,
+        approvedAt: new Date(),
+      });
+    }
+
+    return APPROVAL_CHECK_RESULT.APPROVED;
+  }
+
   const existing = await approvalRepository.findByLineUserId(
     userProfile.userId,
   );
@@ -61,7 +90,7 @@ const checkApprovalStatus = async (
       pictureUrl: userProfile.pictureUrl,
       statusMessage: userProfile.statusMessage,
     });
-    return "NEW";
+    return APPROVAL_CHECK_RESULT.NEW;
   }
 
   // อัปเดตโปรไฟล์ล่าสุดถ้ามีการเปลี่ยนแปลง
@@ -81,15 +110,17 @@ const checkApprovalStatus = async (
   }
 
   // ตรวจสอบว่า APPROVED แต่หมดอายุแล้วหรือยัง
-  if (existing.status === "APPROVED" && existing.expiresAt) {
+  if (existing.status === APPROVAL_CHECK_RESULT.APPROVED && existing.expiresAt) {
     if (existing.expiresAt < new Date()) {
       // หมดอายุ → เปลี่ยนกลับเป็น PENDING
-      await approvalRepository.update(existing.id, { status: "PENDING" });
-      return "PENDING";
+      await approvalRepository.update(existing.id, {
+        status: APPROVAL_CHECK_RESULT.PENDING,
+      });
+      return APPROVAL_CHECK_RESULT.PENDING;
     }
   }
 
-  return existing.status;
+  return existing.status as ApprovalCheckResult;
 };
 
 /**
@@ -130,7 +161,7 @@ const approveUser = async (
   expiresAt?: Date,
 ): Promise<LineApprovalRequest> => {
   const record = await approvalRepository.update(id, {
-    status: "APPROVED",
+    status: APPROVAL_CHECK_RESULT.APPROVED,
     approvedBy: adminUserId,
     approvedAt: new Date(),
     expiresAt: expiresAt ?? null,
@@ -158,7 +189,7 @@ const rejectUser = async (
   rejectReason?: string,
 ): Promise<LineApprovalRequest> => {
   const record = await approvalRepository.update(id, {
-    status: "REJECTED",
+    status: APPROVAL_CHECK_RESULT.REJECTED,
     approvedBy: adminUserId,
     approvedAt: new Date(),
     rejectReason,
@@ -178,7 +209,7 @@ const rejectLineUser = async (
   rejectReason?: string,
 ): Promise<LineApprovalRequest> => {
   const record = await approvalRepository.upsertByLineUserId(lineUserId, {
-    status: "REJECTED",
+    status: APPROVAL_CHECK_RESULT.REJECTED,
     approvedBy: adminUserId,
     approvedAt: new Date(),
     rejectReason,

--- a/src/features/line/types/approval.types.ts
+++ b/src/features/line/types/approval.types.ts
@@ -1,0 +1,33 @@
+/**
+ * LINE Approval Type Definitions
+ * ประเภทข้อมูลสำหรับระบบอนุมัติ LINE Messaging API
+ */
+
+/**
+ * ผลลัพธ์การตรวจสอบสถานะอนุมัติ
+ * - "APPROVED"  → ผ่านอนุมัติแล้ว ใช้งานได้ปกติ
+ * - "PENDING"   → รอการอนุมัติ
+ * - "REJECTED"  → ถูกปฏิเสธ
+ * - "NEW"       → ยังไม่เคยขอ (เพิ่งสร้าง request ใหม่)
+ */
+export type ApprovalCheckResult = "APPROVED" | "PENDING" | "REJECTED" | "NEW";
+
+/**
+ * Constants สำหรับสถานะการตรวจสอบ
+ * ใช้แทน hardcoded strings เพื่อความชัดเจนและป้องกัน typing errors
+ */
+export const APPROVAL_CHECK_RESULT = {
+  APPROVED: "APPROVED" as const,
+  PENDING: "PENDING" as const,
+  REJECTED: "REJECTED" as const,
+  NEW: "NEW" as const,
+} as const;
+
+/**
+ * Type guard สำหรับตรวจสอบค่า ApprovalCheckResult
+ */
+export const isValidApprovalCheckResult = (
+  value: string,
+): value is ApprovalCheckResult => {
+  return Object.values(APPROVAL_CHECK_RESULT).includes(value as ApprovalCheckResult);
+};

--- a/src/hooks/useLineApproval.ts
+++ b/src/hooks/useLineApproval.ts
@@ -1,0 +1,85 @@
+/**
+ * useLineApproval
+ * React hook สำหรับตรวจสอบและจัดการ LINE approval status
+ *
+ * Usage:
+ * ```tsx
+ * const { hasLineApproval, isLoading, needsApproval, refetch } = useLineApproval();
+ *
+ * if (isLoading) return <Loading />;
+ * if (needsApproval) return <PendingApprovalPage />;
+ * ```
+ */
+import { useCallback, useEffect, useState } from "react";
+import { useSession } from "@/lib/auth/client";
+
+interface LineApprovalState {
+  hasLineApproval: boolean;
+  isLoading: boolean;
+  needsApproval: boolean;
+  hasLineAccount: boolean;
+  error?: string;
+}
+
+export const useLineApproval = () => {
+  const { data: session, status } = useSession();
+  const [state, setState] = useState<LineApprovalState>({
+    hasLineApproval: true, // Default: allow access
+    isLoading: true,
+    needsApproval: false,
+    hasLineAccount: false,
+  });
+
+  const checkApproval = useCallback(async () => {
+    let isMounted = true;
+
+    if (status !== "authenticated") {
+      if (isMounted) {
+        setState((prev) => ({
+          ...prev,
+          isLoading: false,
+          hasLineApproval: true,
+          needsApproval: false,
+        }));
+      }
+      return;
+    }
+
+    try {
+      const res = await fetch("/api/auth/check-line-approval");
+      const data = await res.json();
+
+      if (isMounted) {
+        setState({
+          hasLineApproval: data.approved ?? false,
+          isLoading: false,
+          needsApproval: !(data.approved ?? false),
+          hasLineAccount: data.hasLineAccount ?? false,
+        });
+      }
+    } catch (error) {
+      console.error("[useLineApproval] Failed to check:", error);
+      if (isMounted) {
+        setState({
+          hasLineApproval: true, // Fallback: allow on error
+          isLoading: false,
+          needsApproval: false,
+          hasLineAccount: false,
+          error: "Failed to check approval status",
+        });
+      }
+    }
+  }, [status]);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    checkApproval();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [checkApproval]);
+
+  return { ...state, refetch: checkApproval };
+};

--- a/src/lib/auth/approval-guard.ts
+++ b/src/lib/auth/approval-guard.ts
@@ -1,0 +1,166 @@
+/**
+ * LINE Approval Guard
+ * ตรวจสอบ LINE Messaging API approval status สำหรับ web routes
+ *
+ * ใช้ป้องกันไม่ให้ผู้ใช้ที่ยังไม่ได้อนุมัติเข้าถึงฟีเจอร์ต่างๆ
+ */
+import { db } from "@/lib/database/db";
+import { isAdminLineUser } from "./admin";
+import { getServerAuthSession } from "./auth";
+
+/**
+ * ตรวจสอบว่า LINE user ได้รับอนุมัติแล้วหรือไม่
+ * @param userId User ID จาก session
+ * @returns true ถ้าได้รับอนุมัติแล้ว
+ */
+export const isLineUserApproved = async (userId: string): Promise<boolean> => {
+  // 1. ดึง LINE account พร้อมข้อมูล user role
+  const account = await db.account.findFirst({
+    where: {
+      userId,
+      provider: "line",
+    },
+    select: {
+      providerAccountId: true,
+      user: {
+        select: {
+          role: true,
+        },
+      },
+    },
+  });
+
+  if (!account) {
+    // ไม่มี LINE account → ไม่ต้องตรวจสอบ approval (ใช้ login วิธีอื่น)
+    return true;
+  }
+
+  const lineUserId = account.providerAccountId;
+
+  // 2. Admin whitelist → auto-approved
+  if (isAdminLineUser(lineUserId)) {
+    return true;
+  }
+
+  // 2.5. Admin role จาก database → auto-approved
+  if (account.user.role === "admin") {
+    return true;
+  }
+
+  // 3. ตรวจสอบจากฐานข้อมูล
+  const approval = await db.lineApprovalRequest.findUnique({
+    where: {
+      lineUserId,
+    },
+    select: {
+      status: true,
+      expiresAt: true,
+    },
+  });
+
+  if (!approval) {
+    // ยังไม่เคยขอ → ไม่อนุมัติ
+    return false;
+  }
+
+  // 4. ตรวจสอบสถานะ
+  if (approval.status !== "APPROVED") {
+    return false;
+  }
+
+  // 5. ตรวจสอบ expiration ถ้ามี
+  if (approval.expiresAt && approval.expiresAt < new Date()) {
+    // หมดอายุแล้ว
+    return false;
+  }
+
+  return true;
+};
+
+/**
+ * ตรวจสอบและ redirect ถ้า LINE user ยังไม่ได้อนุมัติ
+ * ใช้สำหรับ protect web routes
+ *
+ * @example
+ * ```tsx
+ * beforeLoad: async ({ context }) => {
+ *   const session = await getSession();
+ *   if (!session?.user) return { redirect: '/login' };
+ *
+ *   const hasApproval = await checkLineApproval(session.user.id);
+ *   if (!hasApproval) {
+ *     return { redirect: '/pending-approval' };
+ *   }
+ * }
+ * ```
+ */
+export const checkLineApproval = async (userId: string): Promise<boolean> => {
+  return isLineUserApproved(userId);
+};
+
+/**
+ * Cron Job LINE Approval Guard
+ * ตรวจสอบ LINE approval สำหรับ cron jobs
+ * ถ้าไม่ได้อนุมัติจะ return 403 response ทันที
+ *
+ * @example
+ * ```ts
+ * export async function GET() {
+ *   const approvalCheck = await checkCronLineApproval();
+ *   if (!approvalCheck.approved) {
+ *     return approvalCheck.response;
+ *   }
+ *
+ *   // ... cron job logic
+ * }
+ * ```
+ */
+export const checkCronLineApproval = async (): Promise<{
+  approved: boolean;
+  response?: Response;
+}> => {
+  try {
+    const session = await getServerAuthSession();
+
+    if (!session?.user?.id) {
+      return {
+        approved: false,
+        response: Response.json(
+          {
+            success: false,
+            error: "LINE approval required: No authenticated session",
+          },
+          { status: 403 },
+        ),
+      };
+    }
+
+    const hasApproval = await isLineUserApproved(session.user.id);
+
+    if (!hasApproval) {
+      return {
+        approved: false,
+        response: Response.json(
+          {
+            success: false,
+            error: "LINE approval required: LINE Messaging API not approved",
+          },
+          { status: 403 },
+        ),
+      };
+    }
+
+    return { approved: true };
+  } catch (error) {
+    return {
+      approved: false,
+      response: Response.json(
+        {
+          success: false,
+          error: "Failed to check LINE approval",
+        },
+        { status: 500 },
+      ),
+    };
+  }
+};

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as ThaiNamesGeneratorRouteImport } from './routes/thai-names-generator'
 import { Route as ThaiIdRouteImport } from './routes/thai-id'
+import { Route as PendingApprovalRouteImport } from './routes/pending-approval'
 import { Route as MonitoringRouteImport } from './routes/monitoring'
 import { Route as LogoutRouteImport } from './routes/logout'
 import { Route as LoginRouteImport } from './routes/login'
@@ -47,6 +48,7 @@ import { Route as ApiCronEnhancedCheckoutReminderRouteImport } from './routes/ap
 import { Route as ApiCronCheckoutReminderRouteImport } from './routes/api/cron/checkout-reminder'
 import { Route as ApiCronCheckInReminderRouteImport } from './routes/api/cron/check-in-reminder'
 import { Route as ApiCronAutoCheckoutRouteImport } from './routes/api/cron/auto-checkout'
+import { Route as ApiAuthCheckLineApprovalRouteImport } from './routes/api/auth/check-line-approval'
 import { Route as ApiAuthSplatRouteImport } from './routes/api/auth/$'
 import { Route as ApiAttendanceUpdateRouteImport } from './routes/api/attendance/update'
 import { Route as ApiAdminDebugRouteImport } from './routes/api/admin/debug'
@@ -61,6 +63,11 @@ const ThaiNamesGeneratorRoute = ThaiNamesGeneratorRouteImport.update({
 const ThaiIdRoute = ThaiIdRouteImport.update({
   id: '/thai-id',
   path: '/thai-id',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const PendingApprovalRoute = PendingApprovalRouteImport.update({
+  id: '/pending-approval',
+  path: '/pending-approval',
   getParentRoute: () => rootRouteImport,
 } as any)
 const MonitoringRoute = MonitoringRouteImport.update({
@@ -247,6 +254,12 @@ const ApiCronAutoCheckoutRoute = ApiCronAutoCheckoutRouteImport.update({
   path: '/api/cron/auto-checkout',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiAuthCheckLineApprovalRoute =
+  ApiAuthCheckLineApprovalRouteImport.update({
+    id: '/api/auth/check-line-approval',
+    path: '/api/auth/check-line-approval',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const ApiAuthSplatRoute = ApiAuthSplatRouteImport.update({
   id: '/api/auth/$',
   path: '/api/auth/$',
@@ -285,6 +298,7 @@ export interface FileRoutesByFullPath {
   '/login': typeof LoginRoute
   '/logout': typeof LogoutRoute
   '/monitoring': typeof MonitoringRoute
+  '/pending-approval': typeof PendingApprovalRoute
   '/thai-id': typeof ThaiIdRoute
   '/thai-names-generator': typeof ThaiNamesGeneratorRoute
   '/api/attendance-push': typeof ApiAttendancePushRoute
@@ -297,6 +311,7 @@ export interface FileRoutesByFullPath {
   '/api/admin/debug': typeof ApiAdminDebugRoute
   '/api/attendance/update': typeof ApiAttendanceUpdateRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
+  '/api/auth/check-line-approval': typeof ApiAuthCheckLineApprovalRoute
   '/api/cron/auto-checkout': typeof ApiCronAutoCheckoutRoute
   '/api/cron/check-in-reminder': typeof ApiCronCheckInReminderRoute
   '/api/cron/checkout-reminder': typeof ApiCronCheckoutReminderRoute
@@ -330,6 +345,7 @@ export interface FileRoutesByTo {
   '/login': typeof LoginRoute
   '/logout': typeof LogoutRoute
   '/monitoring': typeof MonitoringRoute
+  '/pending-approval': typeof PendingApprovalRoute
   '/thai-id': typeof ThaiIdRoute
   '/thai-names-generator': typeof ThaiNamesGeneratorRoute
   '/api/attendance-push': typeof ApiAttendancePushRoute
@@ -342,6 +358,7 @@ export interface FileRoutesByTo {
   '/api/admin/debug': typeof ApiAdminDebugRoute
   '/api/attendance/update': typeof ApiAttendanceUpdateRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
+  '/api/auth/check-line-approval': typeof ApiAuthCheckLineApprovalRoute
   '/api/cron/auto-checkout': typeof ApiCronAutoCheckoutRoute
   '/api/cron/check-in-reminder': typeof ApiCronCheckInReminderRoute
   '/api/cron/checkout-reminder': typeof ApiCronCheckoutReminderRoute
@@ -376,6 +393,7 @@ export interface FileRoutesById {
   '/login': typeof LoginRoute
   '/logout': typeof LogoutRoute
   '/monitoring': typeof MonitoringRoute
+  '/pending-approval': typeof PendingApprovalRoute
   '/thai-id': typeof ThaiIdRoute
   '/thai-names-generator': typeof ThaiNamesGeneratorRoute
   '/api/attendance-push': typeof ApiAttendancePushRoute
@@ -388,6 +406,7 @@ export interface FileRoutesById {
   '/api/admin/debug': typeof ApiAdminDebugRoute
   '/api/attendance/update': typeof ApiAttendanceUpdateRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
+  '/api/auth/check-line-approval': typeof ApiAuthCheckLineApprovalRoute
   '/api/cron/auto-checkout': typeof ApiCronAutoCheckoutRoute
   '/api/cron/check-in-reminder': typeof ApiCronCheckInReminderRoute
   '/api/cron/checkout-reminder': typeof ApiCronCheckoutReminderRoute
@@ -423,6 +442,7 @@ export interface FileRouteTypes {
     | '/login'
     | '/logout'
     | '/monitoring'
+    | '/pending-approval'
     | '/thai-id'
     | '/thai-names-generator'
     | '/api/attendance-push'
@@ -435,6 +455,7 @@ export interface FileRouteTypes {
     | '/api/admin/debug'
     | '/api/attendance/update'
     | '/api/auth/$'
+    | '/api/auth/check-line-approval'
     | '/api/cron/auto-checkout'
     | '/api/cron/check-in-reminder'
     | '/api/cron/checkout-reminder'
@@ -468,6 +489,7 @@ export interface FileRouteTypes {
     | '/login'
     | '/logout'
     | '/monitoring'
+    | '/pending-approval'
     | '/thai-id'
     | '/thai-names-generator'
     | '/api/attendance-push'
@@ -480,6 +502,7 @@ export interface FileRouteTypes {
     | '/api/admin/debug'
     | '/api/attendance/update'
     | '/api/auth/$'
+    | '/api/auth/check-line-approval'
     | '/api/cron/auto-checkout'
     | '/api/cron/check-in-reminder'
     | '/api/cron/checkout-reminder'
@@ -513,6 +536,7 @@ export interface FileRouteTypes {
     | '/login'
     | '/logout'
     | '/monitoring'
+    | '/pending-approval'
     | '/thai-id'
     | '/thai-names-generator'
     | '/api/attendance-push'
@@ -525,6 +549,7 @@ export interface FileRouteTypes {
     | '/api/admin/debug'
     | '/api/attendance/update'
     | '/api/auth/$'
+    | '/api/auth/check-line-approval'
     | '/api/cron/auto-checkout'
     | '/api/cron/check-in-reminder'
     | '/api/cron/checkout-reminder'
@@ -559,6 +584,7 @@ export interface RootRouteChildren {
   LoginRoute: typeof LoginRoute
   LogoutRoute: typeof LogoutRoute
   MonitoringRoute: typeof MonitoringRoute
+  PendingApprovalRoute: typeof PendingApprovalRoute
   ThaiIdRoute: typeof ThaiIdRoute
   ThaiNamesGeneratorRoute: typeof ThaiNamesGeneratorRoute
   ApiAttendancePushRoute: typeof ApiAttendancePushRoute
@@ -571,6 +597,7 @@ export interface RootRouteChildren {
   ApiAdminDebugRoute: typeof ApiAdminDebugRoute
   ApiAttendanceUpdateRoute: typeof ApiAttendanceUpdateRoute
   ApiAuthSplatRoute: typeof ApiAuthSplatRoute
+  ApiAuthCheckLineApprovalRoute: typeof ApiAuthCheckLineApprovalRoute
   ApiCronAutoCheckoutRoute: typeof ApiCronAutoCheckoutRoute
   ApiCronCheckInReminderRoute: typeof ApiCronCheckInReminderRoute
   ApiCronCheckoutReminderRoute: typeof ApiCronCheckoutReminderRoute
@@ -605,6 +632,13 @@ declare module '@tanstack/react-router' {
       path: '/thai-id'
       fullPath: '/thai-id'
       preLoaderRoute: typeof ThaiIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/pending-approval': {
+      id: '/pending-approval'
+      path: '/pending-approval'
+      fullPath: '/pending-approval'
+      preLoaderRoute: typeof PendingApprovalRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/monitoring': {
@@ -859,6 +893,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiCronAutoCheckoutRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/auth/check-line-approval': {
+      id: '/api/auth/check-line-approval'
+      path: '/api/auth/check-line-approval'
+      fullPath: '/api/auth/check-line-approval'
+      preLoaderRoute: typeof ApiAuthCheckLineApprovalRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/auth/$': {
       id: '/api/auth/$'
       path: '/api/auth/$'
@@ -943,6 +984,7 @@ const rootRouteChildren: RootRouteChildren = {
   LoginRoute: LoginRoute,
   LogoutRoute: LogoutRoute,
   MonitoringRoute: MonitoringRoute,
+  PendingApprovalRoute: PendingApprovalRoute,
   ThaiIdRoute: ThaiIdRoute,
   ThaiNamesGeneratorRoute: ThaiNamesGeneratorRoute,
   ApiAttendancePushRoute: ApiAttendancePushRoute,
@@ -955,6 +997,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiAdminDebugRoute: ApiAdminDebugRoute,
   ApiAttendanceUpdateRoute: ApiAttendanceUpdateRoute,
   ApiAuthSplatRoute: ApiAuthSplatRoute,
+  ApiAuthCheckLineApprovalRoute: ApiAuthCheckLineApprovalRoute,
   ApiCronAutoCheckoutRoute: ApiCronAutoCheckoutRoute,
   ApiCronCheckInReminderRoute: ApiCronCheckInReminderRoute,
   ApiCronCheckoutReminderRoute: ApiCronCheckoutReminderRoute,

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -9,12 +9,15 @@ import {
   Scripts,
   Link,
   createRootRouteWithContext,
+  redirect,
 } from "@tanstack/react-router";
 import { TanStackDevtools } from "@tanstack/react-devtools";
 import { TanStackRouterDevtoolsPanel } from "@tanstack/react-router-devtools";
 import { createServerFn } from "@tanstack/react-start";
 import { getRequest } from "@tanstack/react-start/server";
 import { getServerAuthSession } from "@/lib/auth";
+import { db } from "@/lib/database/db";
+import { isAdminLineUser } from "@/lib/auth/admin";
 import "../input.css";
 import "@/styles/dca-theme.css";
 
@@ -26,9 +29,109 @@ const fetchSession = createServerFn({ method: "GET" }).handler(async () => {
   return getServerAuthSession(getRequest());
 });
 
+const checkLineApproval = createServerFn({ method: "GET" }).handler(async () => {
+  const session = await getServerAuthSession(getRequest());
+
+  if (!session?.user?.id) {
+    return false;
+  }
+
+  // 1. Check if user has LINE account
+  const account = await db.account.findFirst({
+    where: {
+      userId: session.user.id,
+      provider: "line",
+    },
+    select: {
+      providerAccountId: true,
+      user: {
+        select: {
+          role: true,
+        },
+      },
+    },
+  });
+
+  if (!account) {
+    // No LINE account → no approval needed
+    return true;
+  }
+
+  const lineUserId = account.providerAccountId;
+
+  // 2. Admin whitelist → auto-approved
+  if (isAdminLineUser(lineUserId)) {
+    return true;
+  }
+
+  // 2.5. Admin role from database → auto-approved
+  if (account.user.role === "admin") {
+    return true;
+  }
+
+  // 3. Check database approval status
+  const approval = await db.lineApprovalRequest.findUnique({
+    where: {
+      lineUserId,
+    },
+    select: {
+      status: true,
+      expiresAt: true,
+    },
+  });
+
+  if (!approval) {
+    // Never requested → not approved
+    return false;
+  }
+
+  // 4. Check status
+  if (approval.status !== "APPROVED") {
+    return false;
+  }
+
+  // 5. Check expiration
+  if (approval.expiresAt && approval.expiresAt < new Date()) {
+    // Expired
+    return false;
+  }
+
+  return true;
+});
+
 export const Route = createRootRouteWithContext<RouterContext>()({
-  beforeLoad: async () => {
+  beforeLoad: async ({ location }) => {
     const session = await fetchSession();
+
+    // ตรวจสอบ LINE approval สำหรับ protected routes
+    // Skip check สำหรับ:
+    // - Login page
+    // - Pending approval page
+    // - Public pages
+    const skipApprovalCheck = [
+      "/",
+      "/login",
+      "/logout",
+      "/pending-approval",
+      "/api",
+    ];
+
+    const shouldSkip = skipApprovalCheck.some((path) =>
+      location.pathname.startsWith(path),
+    );
+
+    if (!shouldSkip && session?.user?.id) {
+      // Call server function to check approval
+      const hasApproval = await checkLineApproval();
+
+      if (!hasApproval) {
+        // Redirect ไป pending approval page
+        throw redirect({
+          to: "/pending-approval",
+        });
+      }
+    }
+
     return { session };
   },
   head: () => ({

--- a/src/routes/api/admin/debug.tsx
+++ b/src/routes/api/admin/debug.tsx
@@ -12,21 +12,14 @@ import { env } from "@/env.mjs";
 export async function GET() {
   const session = await getServerAuthSession();
 
-  // 1. Session info
-  const sessionInfo = {
-    hasSession: !!session,
-    userId: session?.user?.id ?? null,
-    userName: session?.user?.name ?? null,
-  };
-
+  // 🔐 SECURITY: Check authentication
   if (!session?.user?.id) {
     return Response.json({
       error: "Not authenticated",
-      session: sessionInfo,
-    });
+    }, { status: 401 });
   }
 
-  // 2. Account info
+  // 🔐 SECURITY: Check LINE account
   const account = await db.account.findFirst({
     where: {
       userId: session.user.id,
@@ -38,26 +31,36 @@ export async function GET() {
     },
   });
 
+  if (!account) {
+    return Response.json({
+      error: "No LINE account found",
+    }, { status: 403 });
+  }
+
+  // 🔐 SECURITY: Check admin permission
+  const canManage = await canManageApprovalsAsync(account.providerAccountId);
+
+  if (!canManage) {
+    return Response.json({
+      error: "Forbidden: Admin access required",
+    }, { status: 403 });
+  }
+
+  // 1. Session info
+  const sessionInfo = {
+    hasSession: !!session,
+    userId: session?.user?.id ?? null,
+    userName: session?.user?.name ?? null,
+  };
+
+  // 2. Account info
   const accountInfo = {
     hasLineAccount: !!account,
     provider: account?.provider ?? null,
     lineUserId: account?.providerAccountId ?? null,
   };
 
-  if (!account) {
-    return Response.json({
-      error: "No LINE account found",
-      session: sessionInfo,
-      account: accountInfo,
-      hint: "Login ด้วย LINE ก่อน",
-    });
-  }
-
   // 3. Env config
-  const isDatabaseOrWhitelistAdmin = await canManageApprovalsAsync(
-    account.providerAccountId,
-  );
-
   const envConfig = {
     adminLineUserIds: env.ADMIN_LINE_USER_IDS ?? "NOT_SET",
     parsedIds: env.ADMIN_LINE_USER_IDS
@@ -65,7 +68,7 @@ export async function GET() {
       : [],
     yourLineUserId: account.providerAccountId,
     isInWhitelist: canManageApprovals(account.providerAccountId),
-    canManageWithDatabase: isDatabaseOrWhitelistAdmin,
+    canManageWithDatabase: canManage,
   };
 
   // 4. Detailed check
@@ -83,7 +86,7 @@ export async function GET() {
     whitelist: parsedIds,
     matchedIndex,
     isMatch: matchedIndex !== -1,
-    canManage: isDatabaseOrWhitelistAdmin,
+    canManage,
   };
 
   return Response.json({
@@ -91,7 +94,6 @@ export async function GET() {
     account: accountInfo,
     envConfig,
     details,
-    error: details.canManage ? null : "Not in whitelist or database admins",
   });
 }
 

--- a/src/routes/api/auth/check-line-approval.tsx
+++ b/src/routes/api/auth/check-line-approval.tsx
@@ -1,0 +1,66 @@
+/**
+ * API Route: /api/auth/check-line-approval
+ * ตรวจสอบว่า LINE user ได้รับการอนุมัติหรือยัง
+ *
+ * GET /api/auth/check-line-approval
+ * Returns: { approved: boolean, lineUserId?: string }
+ */
+import { createFileRoute } from "@tanstack/react-router";
+import { getServerAuthSession } from "@/lib/auth/auth";
+import { isLineUserApproved } from "@/lib/auth/approval-guard";
+import { db } from "@/lib/database/db";
+
+export async function GET(request: Request) {
+  try {
+    const session = await getServerAuthSession(request);
+
+    if (!session?.user?.id) {
+      return Response.json(
+        { error: "Not authenticated" },
+        { status: 401 },
+      );
+    }
+
+    // Check if user has LINE account
+    const account = await db.account.findFirst({
+      where: {
+        userId: session.user.id,
+        provider: "line",
+      },
+      select: {
+        providerAccountId: true,
+      },
+    });
+
+    // If no LINE account, user doesn't need approval
+    if (!account) {
+      return Response.json({
+        approved: true,
+        hasLineAccount: false,
+      });
+    }
+
+    // Check approval status
+    const approved = await isLineUserApproved(session.user.id);
+
+    return Response.json({
+      approved,
+      hasLineAccount: true,
+      lineUserId: account.providerAccountId,
+    });
+  } catch (error) {
+    console.error("[/api/auth/check-line-approval]", error);
+    return Response.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}
+
+export const Route = createFileRoute("/api/auth/check-line-approval")({
+  server: {
+    handlers: {
+      GET: ({ request }) => GET(request),
+    },
+  },
+});

--- a/src/routes/api/cron/auto-checkout.tsx
+++ b/src/routes/api/cron/auto-checkout.tsx
@@ -3,12 +3,19 @@ import { env } from "@/env.mjs";
 import { attendanceService } from "@/features/attendance/services/attendance";
 import { db } from "@/lib/database/db";
 import { AttendanceStatusType } from "@prisma/client";
+import { checkCronLineApproval } from "@/lib/auth/approval-guard";
 
 /**
  * API handler สำหรับการลงชื่อออกงานอัตโนมัติตอนเที่ยงคืน
  * สำหรับพนักงานที่ลืมลงชื่อออกงาน
  */
 export async function GET() {
+  // 🔐 SECURITY: Check LINE Messaging API approval
+  const approvalCheck = await checkCronLineApproval();
+  if (!approvalCheck.approved) {
+    return approvalCheck.response!;
+  }
+
   try {
     const currentTime = new Date();
     const bangkokTime = new Date(

--- a/src/routes/api/cron/check-in-reminder.tsx
+++ b/src/routes/api/cron/check-in-reminder.tsx
@@ -11,6 +11,7 @@ import {
   createReminderSentResponse,
   createNoUsersResponse,
 } from "@/lib/utils/cron-response";
+import { checkCronLineApproval } from "@/lib/auth/approval-guard";
 
 /**
  * Morning Check-in Reminder Cron Job
@@ -30,6 +31,13 @@ export async function GET(req: Request) {
     if (!authResult.success) {
       return createErrorResponse(authResult.error!, authResult.status!);
     }
+
+    // 🔐 SECURITY: Check LINE Messaging API approval
+    const approvalCheck = await checkCronLineApproval();
+    if (!approvalCheck.approved) {
+      return approvalCheck.response!;
+    }
+
     // Get current time and convert to Bangkok timezone
     const currentUTCTime = attendanceService.getCurrentUTCTime();
     const currentThaiTime =

--- a/src/routes/api/cron/checkout-reminder.tsx
+++ b/src/routes/api/cron/checkout-reminder.tsx
@@ -5,14 +5,29 @@ import { db } from "@/lib/database/db";
 import { flexMessage } from "@/lib/utils/line-message-utils";
 import { roundToOneDecimal } from "@/lib/utils/number";
 import { sendPushMessage } from "@/lib/utils/line-push";
+import { validateCronAuth } from "@/lib/utils/cron-auth";
+import { createErrorResponse } from "@/lib/utils/cron-response";
+import { checkCronLineApproval } from "@/lib/auth/approval-guard";
 
 /**
  * Vercel Cron Job for automated checkout reminders
  * This endpoint is called by Vercel's cron scheduler at 16:30 on weekdays
  * It finds all users who checked in but haven't checked out and sends them reminders
  */
-export async function GET(_req: Request) {
+export async function GET(req: Request) {
   try {
+    // 🔐 SECURITY: Authentication check for cron jobs
+    const authResult = validateCronAuth(req);
+    if (!authResult.success) {
+      return createErrorResponse(authResult.error!, authResult.status!);
+    }
+
+    // 🔐 SECURITY: Check LINE Messaging API approval
+    const approvalCheck = await checkCronLineApproval();
+    if (!approvalCheck.approved) {
+      return approvalCheck.response!;
+    }
+
     // Get all users who need checkout reminders AND have the setting enabled
     const usersNeedingReminder =
       await attendanceService.getUsersWithPendingCheckoutAndSettingsEnabled();

--- a/src/routes/api/cron/enhanced-checkout-reminder.tsx
+++ b/src/routes/api/cron/enhanced-checkout-reminder.tsx
@@ -18,6 +18,7 @@ import {
   calculateUserReminderTime,
   calculateUserCompletionTime,
 } from "@/features/attendance/helpers/utils";
+import { checkCronLineApproval } from "@/lib/auth/approval-guard";
 
 /**
  * Enhanced Checkout Reminder with Dynamic Timing
@@ -30,6 +31,12 @@ export async function GET(request: Request) {
     const authHeader = request.headers.get("authorization");
     if (!validateSimpleCronAuth(authHeader)) {
       return Response.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // 🔐 SECURITY: Check LINE Messaging API approval
+    const approvalCheck = await checkCronLineApproval();
+    if (!approvalCheck.approved) {
+      return approvalCheck.response!;
     }
 
     // Get current UTC time

--- a/src/routes/api/line/approvals.tsx
+++ b/src/routes/api/line/approvals.tsx
@@ -47,6 +47,10 @@ const setAdminSchema = z.object({
   isAdmin: z.boolean(),
 });
 
+const unlockSchema = z.object({
+  id: z.string().min(1, "ID ต้องไม่ว่าง"),
+});
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 /**
@@ -260,9 +264,35 @@ export async function POST(request: Request): Promise<Response> {
       }
     }
 
+    if (action === "unlock") {
+      const parsed = unlockSchema.safeParse(body);
+      if (!parsed.success) {
+        return Response.json(
+          { error: "ข้อมูลไม่ถูกต้อง", details: parsed.error.flatten() },
+          { status: 400 },
+        );
+      }
+
+      try {
+        const record = await approvalService.unlockRejectedUser(
+          parsed.data.id,
+          adminLineUserId,
+        );
+
+        return Response.json({
+          message: "ปลดล็อคผู้ใช้เรียบร้อยแล้ว — สามารถขออนุมัติใหม่ได้",
+          data: record,
+        });
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "ปลดล็อคผู้ใช้ไม่สำเร็จ";
+        return Response.json({ error: message }, { status: 400 });
+      }
+    }
+
     return Response.json(
       {
-        error: "action ไม่ถูกต้อง — ใช้ approve, reject, stats, หรือ set-admin",
+        error: "action ไม่ถูกต้อง — ใช้ approve, reject, unlock, stats, หรือ set-admin",
       },
       { status: 400 },
     );

--- a/src/routes/attendance-report.tsx
+++ b/src/routes/attendance-report.tsx
@@ -28,6 +28,8 @@ import {
   MonthSelector,
 } from "@/components/attendance";
 import { useAttendanceReport } from "@/hooks/useAttendanceReport";
+import { PendingApprovalModal } from "@/components/auth/PendingApprovalModal";
+import { useLineApproval } from "@/hooks/useLineApproval";
 
 // Register Chart.js components
 ChartJS.register(
@@ -65,6 +67,8 @@ function AttendanceReportPage() {
     updateAttendance,
   } = useAttendanceReport();
 
+  const { needsApproval } = useLineApproval();
+
   // 🔐 SECURITY: Show loading while checking authentication
   if (status === "loading") {
     return <AuthLoadingScreen />;
@@ -76,7 +80,11 @@ function AttendanceReportPage() {
   }
 
   return (
-    <div id="attendance-report-page" className="min-h-screen w-full">
+    <>
+      {/* Pending Approval Modal */}
+      <PendingApprovalModal open={needsApproval} />
+
+      <div id="attendance-report-page" className="min-h-screen w-full">
       <div
         id="attendance-report-container"
         className="mx-auto max-w-full px-4 py-8"
@@ -193,6 +201,7 @@ function AttendanceReportPage() {
         </div>
       </div>
     </div>
+    </>
   );
 }
 

--- a/src/routes/dashboard.tsx
+++ b/src/routes/dashboard.tsx
@@ -5,6 +5,8 @@ import { useSession } from "@/lib/auth/client";
 import { useEffect, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useSafeHydration } from "@/hooks/useHydrationSafe";
+import { PendingApprovalModal } from "@/components/auth/PendingApprovalModal";
+import { useLineApproval } from "@/hooks/useLineApproval";
 import {
   Calendar,
   FileText,
@@ -20,6 +22,7 @@ function DashboardPage() {
   const { data: session, status } = useSession();
   const navigate = useNavigate();
   const [isAdmin, setIsAdmin] = useState(false);
+  const { needsApproval, isLoading: approvalLoading, refetch } = useLineApproval();
 
   const todayLabel = useSafeHydration("...", () =>
     new Intl.DateTimeFormat("th-TH", {
@@ -54,12 +57,6 @@ function DashboardPage() {
     };
   }, [status]);
 
-  useEffect(() => {
-    if (status === "unauthenticated") {
-      void navigate({ to: "/" });
-    }
-  }, [navigate, status]);
-
   if (status === "loading") {
     return (
       <div
@@ -77,6 +74,7 @@ function DashboardPage() {
     return null;
   }
 
+  // Quick actions configuration
   const quickActions = [
     {
       id: "attendance",
@@ -145,10 +143,15 @@ function DashboardPage() {
   ];
 
   return (
-    <div
-      id="dashboard-container"
-      className="container mx-auto max-w-6xl px-4 py-8"
-    >
+    <>
+      {/* Pending Approval Modal */}
+      <PendingApprovalModal open={needsApproval} />
+
+      {/* Dashboard Content */}
+      <div
+        id="dashboard-container"
+        className="container mx-auto max-w-6xl px-4 py-8"
+      >
       <div id="dashboard-content" className="space-y-8">
         {/* Header */}
         <div id="dashboard-header" className="space-y-2">
@@ -358,6 +361,7 @@ function DashboardPage() {
         </div>
       </div>
     </div>
+    </>
   );
 }
 

--- a/src/routes/dca-history.tsx
+++ b/src/routes/dca-history.tsx
@@ -10,6 +10,8 @@ import { DcaInfoBox } from "@/features/dca/components/DcaInfoBox";
 import { DcaSummaryCards } from "@/features/dca/components/DcaSummaryCards";
 import { useDcaHistoryData } from "@/features/dca/hooks/useDcaHistoryData";
 import { useDcaRealtimeUpdates } from "@/features/dca/hooks/useDcaRealtimeUpdates";
+import { PendingApprovalModal } from "@/components/auth/PendingApprovalModal";
+import { useLineApproval } from "@/hooks/useLineApproval";
 
 function DcaHistoryPage() {
   const [page, setPage] = useState(1);
@@ -20,6 +22,8 @@ function DcaHistoryPage() {
     useDcaHistoryData(page, limit);
 
   useDcaRealtimeUpdates({ onUpdate: refetchAll });
+
+  const { needsApproval } = useLineApproval();
 
   const handleAddSuccess = useCallback(() => {
     setPage(1);
@@ -32,7 +36,11 @@ function DcaHistoryPage() {
   }, [refetchAll]);
 
   return (
-    <div id="dca-history-page" className="bg-background min-h-screen w-full">
+    <>
+      {/* Pending Approval Modal */}
+      <PendingApprovalModal open={needsApproval} />
+
+      <div id="dca-history-page" className="bg-background min-h-screen w-full">
       <div
         id="dca-history-container"
         className="container mx-auto max-w-7xl px-4 py-8"
@@ -99,6 +107,7 @@ function DcaHistoryPage() {
         />
       )}
     </div>
+    </>
   );
 }
 

--- a/src/routes/leave.tsx
+++ b/src/routes/leave.tsx
@@ -1,11 +1,20 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { LeaveForm } from "@/components/attendance/LeaveForm";
+import { PendingApprovalModal } from "@/components/auth/PendingApprovalModal";
+import { useLineApproval } from "@/hooks/useLineApproval";
 
 function LeavePage() {
+  const { needsApproval } = useLineApproval();
+
   return (
-    <main className="flex h-full min-h-screen w-full flex-col items-center justify-center p-4 transition-colors duration-500 sm:p-6 lg:p-8">
-      <LeaveForm />
-    </main>
+    <>
+      {/* Pending Approval Modal */}
+      <PendingApprovalModal open={needsApproval} />
+
+      <main className="flex h-full min-h-screen w-full flex-col items-center justify-center p-4 transition-colors duration-500 sm:p-6 lg:p-8">
+        <LeaveForm />
+      </main>
+    </>
   );
 }
 

--- a/src/routes/line-approval.tsx
+++ b/src/routes/line-approval.tsx
@@ -31,6 +31,8 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { PendingApprovalModal } from "@/components/auth/PendingApprovalModal";
+import { useLineApproval } from "@/hooks/useLineApproval";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -280,6 +282,7 @@ function RejectDialog({
 function LineApprovalPage() {
   const { data: session, status: authStatus } = useSession();
   const navigate = useNavigate();
+  const { needsApproval } = useLineApproval();
 
   const [activeTab, setActiveTab] = useState<ApprovalTab>("ALL");
   const [listData, setListData] = useState<ListResponse | null>(null);
@@ -450,6 +453,36 @@ function LineApprovalPage() {
     }
   };
 
+  const handleUnlock = async (req: ApprovalRequest) => {
+    if (!req.approvalId) {
+      showToast("error", "ไม่พบคำขออนุมัติ");
+      return;
+    }
+    setActionLoading(req.id);
+    try {
+      const res = await fetch("/api/line/approvals", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          action: "unlock",
+          id: req.approvalId,
+        }),
+      });
+      const json = await res.json();
+      if (res.status === 403) {
+        setPermissionError(json.error ?? "คุณไม่มีสิทธิ์ดำเนินการนี้");
+        return;
+      }
+      if (!res.ok) throw new Error(json.error ?? "ปลดล็อคไม่สำเร็จ");
+      showToast("success", "ปลดล็อคผู้ใช้เรียบร้อยแล้ว ✅");
+      await Promise.all([fetchList(), fetchStats()]);
+    } catch (err: any) {
+      showToast("error", err.message ?? "เกิดข้อผิดพลาด");
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
   if (authStatus === "loading") {
     return (
       <div className="flex min-h-screen items-center justify-center">
@@ -492,10 +525,14 @@ function LineApprovalPage() {
   }
 
   return (
-    <div
-      id="line-approval-page"
-      className="min-h-screen w-full bg-slate-50 pb-16 text-slate-950 dark:bg-[#15131f] dark:text-slate-100"
-    >
+    <>
+      {/* Pending Approval Modal */}
+      <PendingApprovalModal open={needsApproval} />
+
+      <div
+        id="line-approval-page"
+        className="min-h-screen w-full bg-slate-50 pb-16 text-slate-950 dark:bg-[#15131f] dark:text-slate-100"
+      >
       {/* Toast */}
       {toast && (
         <div
@@ -712,7 +749,19 @@ function LineApprovalPage() {
                             ? "ยกเลิก Admin"
                             : "ตั้งเป็น Admin"}
                       </Button>
-                      {req.status !== "REJECTED" && (
+                      {req.status === "REJECTED" && req.approvalId ? (
+                        <Button
+                          size="sm"
+                          className="gap-1.5 bg-blue-600 text-white hover:bg-blue-700"
+                          onClick={() => void handleUnlock(req)}
+                          disabled={actionLoading === req.id}
+                        >
+                          <RefreshCw className="h-4 w-4" />
+                          {actionLoading === req.id
+                            ? "กำลังดำเนินการ..."
+                            : "ขอใหม่"}
+                        </Button>
+                      ) : (
                         <>
                           {req.status === "PENDING" && (
                             <Button
@@ -782,6 +831,7 @@ function LineApprovalPage() {
         isLoading={actionLoading !== null}
       />
     </div>
+    </>
   );
 }
 

--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -8,7 +8,11 @@ import { LineLoginButton } from "@/components/ui/LineLoginButton";
 function LoginPage() {
   const { status } = useSession();
   const search = useSearch({ strict: false }) as { callbackUrl?: string };
-  const callbackUrl = typeof search.callbackUrl === "string" ? search.callbackUrl : "/";
+  // Only allow relative paths to prevent open redirect.
+  // Reject absolute URLs (https://evil.com) and protocol-relative URLs (//evil.com).
+  const rawCallback = typeof search.callbackUrl === "string" ? search.callbackUrl : "/";
+  const callbackUrl =
+    rawCallback.startsWith("/") && !rawCallback.startsWith("//") ? rawCallback : "/";
 
   React.useEffect(() => {
     if (status === "authenticated") {

--- a/src/routes/monitoring.tsx
+++ b/src/routes/monitoring.tsx
@@ -25,6 +25,7 @@ import {
   RefreshCw,
   Clock,
   Users,
+  ShieldCheck,
 } from "lucide-react";
 import {
   AuthLoadingScreen,
@@ -32,6 +33,8 @@ import {
   LoadingSpinner,
 } from "@/components/attendance";
 import { useChartTheme } from "@/hooks/useChartTheme";
+import { PendingApprovalModal } from "@/components/auth/PendingApprovalModal";
+import { useLineApproval } from "@/hooks/useLineApproval";
 
 // Register Chart.js components
 ChartJS.register(
@@ -110,6 +113,7 @@ function MonitoringDashboardPage() {
   const [lastUpdate, setLastUpdate] = useState<Date | null>(null);
   const [autoRefresh, setAutoRefresh] = useState(true);
   const { mounted, getChartOptions, getDoughnutOptions } = useChartTheme();
+  const { needsApproval } = useLineApproval();
 
   // Fetch monitoring data
   const fetchMonitoringData = async () => {
@@ -142,6 +146,32 @@ function MonitoringDashboardPage() {
   // Loading states
   if (status === "loading") return <AuthLoadingScreen />;
   if (!session) return <LoginPrompt />;
+
+  // 🔐 SECURITY: Admin-only access
+  if (session.user?.role !== "admin") {
+    return (
+      <div className="bg-background flex min-h-screen items-center justify-center p-4">
+        <div className="border-border bg-card max-w-md rounded-xl border p-8 text-center shadow-lg">
+          <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-red-100 text-red-600 dark:bg-red-900/30">
+            <Shield className="h-8 w-8" />
+          </div>
+          <h2 className="text-foreground mb-2 text-xl font-bold">
+            ไม่มีสิทธิเข้าถึง
+          </h2>
+          <p className="text-muted-foreground mb-6 text-sm">
+            หน้า Monitoring สำหรับ Admin เท่านั้น
+          </p>
+          <a
+            href="/dashboard"
+            className="bg-primary text-primary-foreground inline-flex w-full items-center justify-center rounded-md px-4 py-2 text-sm font-medium transition-opacity hover:opacity-90"
+          >
+            กลับหน้าหลัก
+          </a>
+        </div>
+      </div>
+    );
+  }
+
   if (!mounted) return <LoadingSpinner message="กำลังโหลด Dashboard..." />;
 
   const getStatusColor = (status: string) => {
@@ -237,380 +267,380 @@ function MonitoringDashboardPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
-      {/* Header */}
-      <header className="border-b border-gray-200 bg-white shadow dark:border-gray-700 dark:bg-gray-800">
-        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center justify-between py-4">
-            <div>
-              <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
-                📊 System Monitoring Dashboard
-              </h1>
-              <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">
-                Real-time system health and performance monitoring
-              </p>
-            </div>
-            <div className="flex items-center gap-4">
-              {lastUpdate && (
-                <div className="text-sm text-gray-500 dark:text-gray-400">
-                  <Clock className="mr-1 inline h-4 w-4" />
-                  Last updated: {lastUpdate.toLocaleTimeString()}
-                </div>
-              )}
-              <button
-                onClick={fetchMonitoringData}
-                className="p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
-                title="Refresh data"
-              >
-                <RefreshCw className="h-5 w-5" />
-              </button>
-              <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
-                <input
-                  type="checkbox"
-                  checked={autoRefresh}
-                  onChange={(e) => setAutoRefresh(e.target.checked)}
-                  className="rounded"
-                />
-                Auto-refresh
-              </label>
-            </div>
-          </div>
-        </div>
-      </header>
+    <>
+      {/* Pending Approval Modal */}
+      <PendingApprovalModal open={needsApproval} />
 
-      <main className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
-        {error && (
-          <div className="mb-6 rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-700 dark:bg-red-900/20">
-            <div className="flex items-center">
-              <AlertTriangle className="mr-2 h-5 w-5 text-red-500" />
-              <span className="text-red-700 dark:text-red-300">
-                Error: {error}
-              </span>
-            </div>
-          </div>
-        )}
-
-        {monitoringData && (
-          <>
-            {/* System Health Overview */}
-            <div className="mb-8">
-              <h2 className="mb-4 text-xl font-semibold text-gray-900 dark:text-white">
-                System Health Overview
-              </h2>
-              <div className="grid grid-cols-1 gap-6 lg:grid-cols-4">
-                {/* Health Status */}
-                <div className="rounded-lg border border-gray-200 bg-white p-6 shadow dark:border-gray-700 dark:bg-gray-800">
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <p className="text-sm font-medium text-gray-600 dark:text-gray-400">
-                        System Status
-                      </p>
-                      <p
-                        className={`text-2xl font-bold ${getStatusColor(monitoringData.systemHealth.status)}`}
-                      >
-                        {monitoringData.systemHealth.status.toUpperCase()}
-                      </p>
-                      <p className="text-sm text-gray-500 dark:text-gray-400">
-                        Score: {monitoringData.systemHealth.score}/100
-                      </p>
-                    </div>
-                    <Activity
-                      className={`h-8 w-8 ${getStatusColor(monitoringData.systemHealth.status)}`}
-                    />
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+        {/* Header */}
+        <header className="border-b border-gray-200 bg-white shadow dark:border-gray-700 dark:bg-gray-800">
+          <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+            <div className="flex items-center justify-between py-4">
+              <div>
+                <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+                  📊 System Monitoring Dashboard
+                </h1>
+                <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">
+                  Real-time system health and performance monitoring
+                </p>
+              </div>
+              <div className="flex items-center gap-4">
+                {lastUpdate && (
+                  <div className="text-sm text-gray-500 dark:text-gray-400">
+                    <Clock className="mr-1 inline h-4 w-4" />
+                    Last updated: {lastUpdate.toLocaleTimeString()}
                   </div>
-                  <div className="mt-4">
-                    <span
-                      className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${getStatusBadge(monitoringData.systemHealth.status)}`}
-                    >
-                      {monitoringData.systemHealth.status}
+                )}
+                <button
+                  onClick={fetchMonitoringData}
+                  className="p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+                  title="Refresh data"
+                >
+                  <RefreshCw className="h-5 w-5" />
+                </button>
+                <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+                  <input
+                    type="checkbox"
+                    checked={autoRefresh}
+                    onChange={(e) => setAutoRefresh(e.target.checked)}
+                    className="rounded"
+                  />
+                  Auto-refresh
+                </label>
+              </div>
+            </div>
+          </div>
+        </header>
+
+        <main className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+          {error && (
+            <div className="mb-6 rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-700 dark:bg-red-900/20">
+              <div className="flex items-center">
+                <AlertTriangle className="mr-2 h-5 w-5 text-red-500" />
+                <span className="text-red-700 dark:text-red-300">
+                  Error: {error}
+                </span>
+              </div>
+            </div>
+          )}
+
+          {monitoringData && (
+            <>
+              {/* System Health Overview */}
+              <div className="mb-8">
+                <h2 className="mb-4 text-xl font-semibold text-gray-900 dark:text-white">
+                  System Health Overview
+                </h2>
+                <div className="grid grid-cols-1 gap-6 lg:grid-cols-4">
+                  {/* Health Status */}
+                  <div className="rounded-lg border border-gray-200 bg-white p-6 shadow dark:border-gray-700 dark:bg-gray-800">
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <p className="text-sm font-medium text-gray-600 dark:text-gray-400">
+                          System Status
+                        </p>
+                        <p
+                          className={`text-2xl font-bold ${getStatusColor(monitoringData.systemHealth.status)}`}
+                        >
+                          {monitoringData.systemHealth.status.toUpperCase()}
+                        </p>
+                        <p className="text-sm text-gray-500 dark:text-gray-400">
+                          Score: {monitoringData.systemHealth.score}/100
+                        </p>
+                      </div>
+                      <Activity
+                        className={`h-8 w-8 ${getStatusColor(monitoringData.systemHealth.status)}`}
+                      />
+                    </div>
+                    <div className="mt-4">
+                      <span
+                        className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${getStatusBadge(monitoringData.systemHealth.status)}`}
+                      >
+                        {monitoringData.systemHealth.status}
+                      </span>
+                    </div>
+                  </div>
+
+                  {/* Uptime */}
+                  <div className="rounded-lg border border-gray-200 bg-white p-6 shadow dark:border-gray-700 dark:bg-gray-800">
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <p className="text-sm font-medium text-gray-600 dark:text-gray-400">
+                          System Uptime
+                        </p>
+                        <p className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+                          {formatUptime(monitoringData.systemHealth.uptime)}
+                        </p>
+                        <p className="text-sm text-gray-500 dark:text-gray-400">
+                          Since last restart
+                        </p>
+                      </div>
+                      <Clock className="h-8 w-8 text-blue-500" />
+                    </div>
+                  </div>
+
+                  {/* Response Time */}
+                  <div className="rounded-lg border border-gray-200 bg-white p-6 shadow dark:border-gray-700 dark:bg-gray-800">
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <p className="text-sm font-medium text-gray-600 dark:text-gray-400">
+                          Response Time
+                        </p>
+                        <p className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+                          {monitoringData.metrics.responseTime}ms
+                        </p>
+                        <p className="text-sm text-gray-500 dark:text-gray-400">
+                          API response time
+                        </p>
+                      </div>
+                      <Zap className="h-8 w-8 text-yellow-500" />
+                    </div>
+                  </div>
+
+                  {/* Active Users */}
+                  <div className="rounded-lg border border-gray-200 bg-white p-6 shadow dark:border-gray-700 dark:bg-gray-800">
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <p className="text-sm font-medium text-gray-600 dark:text-gray-400">
+                          Active Users
+                        </p>
+                        <p className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+                          {monitoringData.metrics.activeUsers}
+                        </p>
+                        <p className="text-sm text-gray-500 dark:text-gray-400">
+                          Registered users
+                        </p>
+                      </div>
+                      <Users className="h-8 w-8 text-green-500" />
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              {/* Charts Section */}
+              <div className="mb-8 grid grid-cols-1 gap-8 lg:grid-cols-2">
+                {/* Health Score Chart */}
+                <div className="rounded-lg border border-gray-200 bg-white p-6 shadow dark:border-gray-700 dark:bg-gray-800">
+                  <h3 className="mb-4 text-lg font-semibold text-gray-900 dark:text-gray-100">
+                    Health Score
+                  </h3>
+                  <div className="flex h-64 items-center justify-center">
+                    <div style={{ width: "250px", height: "250px" }}>
+                      <Doughnut
+                        data={prepareHealthScoreData()}
+                        options={getDoughnutOptions({
+                          plugins: {
+                            legend: { display: false },
+                          },
+                        })}
+                      />
+                    </div>
+                  </div>
+                  <div className="mt-4 text-center">
+                    <span className="text-3xl font-bold text-gray-900 dark:text-gray-100">
+                      {monitoringData.systemHealth.score}%
                     </span>
                   </div>
                 </div>
 
-                {/* Uptime */}
+                {/* Resource Usage Chart */}
                 <div className="rounded-lg border border-gray-200 bg-white p-6 shadow dark:border-gray-700 dark:bg-gray-800">
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <p className="text-sm font-medium text-gray-600 dark:text-gray-400">
-                        System Uptime
-                      </p>
-                      <p className="text-2xl font-bold text-gray-900 dark:text-gray-100">
-                        {formatUptime(monitoringData.systemHealth.uptime)}
-                      </p>
-                      <p className="text-sm text-gray-500 dark:text-gray-400">
-                        Since last restart
-                      </p>
-                    </div>
-                    <Clock className="h-8 w-8 text-blue-500" />
-                  </div>
-                </div>
-
-                {/* Response Time */}
-                <div className="rounded-lg border border-gray-200 bg-white p-6 shadow dark:border-gray-700 dark:bg-gray-800">
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <p className="text-sm font-medium text-gray-600 dark:text-gray-400">
-                        Response Time
-                      </p>
-                      <p className="text-2xl font-bold text-gray-900 dark:text-gray-100">
-                        {monitoringData.metrics.responseTime}ms
-                      </p>
-                      <p className="text-sm text-gray-500 dark:text-gray-400">
-                        API response time
-                      </p>
-                    </div>
-                    <Zap className="h-8 w-8 text-yellow-500" />
-                  </div>
-                </div>
-
-                {/* Active Users */}
-                <div className="rounded-lg border border-gray-200 bg-white p-6 shadow dark:border-gray-700 dark:bg-gray-800">
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <p className="text-sm font-medium text-gray-600 dark:text-gray-400">
-                        Active Users
-                      </p>
-                      <p className="text-2xl font-bold text-gray-900 dark:text-gray-100">
-                        {monitoringData.metrics.activeUsers}
-                      </p>
-                      <p className="text-sm text-gray-500 dark:text-gray-400">
-                        Registered users
-                      </p>
-                    </div>
-                    <Users className="h-8 w-8 text-green-500" />
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            {/* Charts Section */}
-            <div className="mb-8 grid grid-cols-1 gap-8 lg:grid-cols-2">
-              {/* Health Score Chart */}
-              <div className="rounded-lg border border-gray-200 bg-white p-6 shadow dark:border-gray-700 dark:bg-gray-800">
-                <h3 className="mb-4 text-lg font-semibold text-gray-900 dark:text-gray-100">
-                  Health Score
-                </h3>
-                <div className="flex h-64 items-center justify-center">
-                  <div style={{ width: "250px", height: "250px" }}>
-                    <Doughnut
-                      data={prepareHealthScoreData()}
-                      options={getDoughnutOptions({
+                  <h3 className="mb-4 text-lg font-semibold text-gray-900 dark:text-gray-100">
+                    Resource Usage
+                  </h3>
+                  <div className="h-64">
+                    <Bar
+                      data={prepareResourceUsageData()}
+                      options={getChartOptions({
                         plugins: {
                           legend: { display: false },
+                        },
+                        scales: {
+                          y: {
+                            beginAtZero: true,
+                            max: 100,
+                          },
                         },
                       })}
                     />
                   </div>
                 </div>
-                <div className="mt-4 text-center">
-                  <span className="text-3xl font-bold text-gray-900 dark:text-gray-100">
-                    {monitoringData.systemHealth.score}%
-                  </span>
+              </div>
+
+              {/* Services Status */}
+              <div className="mb-8">
+                <h2 className="mb-4 text-xl font-semibold text-gray-900 dark:text-gray-100">
+                  Services Status
+                </h2>
+                <div className="grid grid-cols-2 gap-4 lg:grid-cols-5">
+                  {Object.entries(monitoringData.services).map(
+                    ([service, status]) => (
+                      <div
+                        key={service}
+                        className="rounded-lg border border-gray-200 bg-white p-4 shadow dark:border-gray-700 dark:bg-gray-800"
+                      >
+                        <div className="flex items-center justify-between">
+                          <div>
+                            <p className="text-sm font-medium capitalize text-gray-900 dark:text-gray-100">
+                              {service.replace(/([A-Z])/g, " $1").trim()}
+                            </p>
+                            <div className="mt-1 flex items-center">
+                              <div
+                                className={`mr-2 h-2 w-2 rounded-full ${status ? "bg-green-500" : "bg-red-500"}`}
+                              />
+                              <span
+                                className={`text-sm ${status ? "text-green-600 dark:text-green-400" : "text-red-600 dark:text-red-400"}`}
+                              >
+                                {status ? "Online" : "Offline"}
+                              </span>
+                            </div>
+                          </div>
+                          {service === "database" && (
+                            <Database className="h-5 w-5 text-gray-400" />
+                          )}
+                          {service === "authentication" && (
+                            <Shield className="h-5 w-5 text-gray-400" />
+                          )}
+                        </div>
+                      </div>
+                    ),
+                  )}
                 </div>
               </div>
 
-              {/* Resource Usage Chart */}
-              <div className="rounded-lg border border-gray-200 bg-white p-6 shadow dark:border-gray-700 dark:bg-gray-800">
-                <h3 className="mb-4 text-lg font-semibold text-gray-900 dark:text-gray-100">
-                  Resource Usage
-                </h3>
-                <div className="h-64">
-                  <Bar
-                    data={prepareResourceUsageData()}
-                    options={getChartOptions({
-                      plugins: {
-                        legend: { display: false },
-                      },
-                      scales: {
-                        y: {
-                          beginAtZero: true,
-                          max: 100,
-                        },
-                      },
-                    })}
-                  />
-                </div>
-              </div>
-            </div>
-
-            {/* Services Status */}
-            <div className="mb-8">
-              <h2 className="mb-4 text-xl font-semibold text-gray-900 dark:text-gray-100">
-                Services Status
-              </h2>
-              <div className="grid grid-cols-2 gap-4 lg:grid-cols-5">
-                {Object.entries(monitoringData.services).map(
-                  ([service, status]) => (
-                    <div
-                      key={service}
-                      className="rounded-lg border border-gray-200 bg-white p-4 shadow dark:border-gray-700 dark:bg-gray-800"
-                    >
-                      <div className="flex items-center justify-between">
-                        <div>
-                          <p className="text-sm font-medium capitalize text-gray-900 dark:text-gray-100">
-                            {service.replace(/([A-Z])/g, " $1").trim()}
-                          </p>
-                          <div className="mt-1 flex items-center">
-                            <div
-                              className={`mr-2 h-2 w-2 rounded-full ${status ? "bg-green-500" : "bg-red-500"}`}
+              {/* Alerts */}
+              {monitoringData.alerts.length > 0 && (
+                <div className="mb-8">
+                  <h2 className="mb-4 text-xl font-semibold text-gray-900 dark:text-gray-100">
+                    Active Alerts
+                  </h2>
+                  <div className="space-y-3">
+                    {monitoringData.alerts.map((alert) => (
+                      <div
+                        key={alert.id}
+                        className={`rounded-lg border p-4 ${alert.level === "critical"
+                            ? "border-red-200 bg-red-50 dark:border-red-700 dark:bg-red-900/20"
+                            : alert.level === "warning"
+                              ? "border-yellow-200 bg-yellow-50 dark:border-yellow-700 dark:bg-yellow-900/20"
+                              : "border-blue-200 bg-blue-50 dark:border-blue-700 dark:bg-blue-900/20"
+                          }`}
+                      >
+                        <div className="flex items-start justify-between">
+                          <div className="flex items-start">
+                            <AlertTriangle
+                              className={`mr-3 mt-0.5 h-5 w-5 ${alert.level === "critical"
+                                  ? "text-red-500"
+                                  : alert.level === "warning"
+                                    ? "text-yellow-500"
+                                    : "text-blue-500"
+                                }`}
                             />
-                            <span
-                              className={`text-sm ${status ? "text-green-600 dark:text-green-400" : "text-red-600 dark:text-red-400"}`}
-                            >
-                              {status ? "Online" : "Offline"}
-                            </span>
+                            <div>
+                              <p className="font-medium text-gray-900 dark:text-gray-100">
+                                {alert.message}
+                              </p>
+                              <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                                {new Date(alert.timestamp).toLocaleString()}
+                              </p>
+                            </div>
                           </div>
-                        </div>
-                        {service === "database" && (
-                          <Database className="h-5 w-5 text-gray-400" />
-                        )}
-                        {service === "authentication" && (
-                          <Shield className="h-5 w-5 text-gray-400" />
-                        )}
-                      </div>
-                    </div>
-                  ),
-                )}
-              </div>
-            </div>
-
-            {/* Alerts */}
-            {monitoringData.alerts.length > 0 && (
-              <div className="mb-8">
-                <h2 className="mb-4 text-xl font-semibold text-gray-900 dark:text-gray-100">
-                  Active Alerts
-                </h2>
-                <div className="space-y-3">
-                  {monitoringData.alerts.map((alert) => (
-                    <div
-                      key={alert.id}
-                      className={`rounded-lg border p-4 ${
-                        alert.level === "critical"
-                          ? "border-red-200 bg-red-50 dark:border-red-700 dark:bg-red-900/20"
-                          : alert.level === "warning"
-                            ? "border-yellow-200 bg-yellow-50 dark:border-yellow-700 dark:bg-yellow-900/20"
-                            : "border-blue-200 bg-blue-50 dark:border-blue-700 dark:bg-blue-900/20"
-                      }`}
-                    >
-                      <div className="flex items-start justify-between">
-                        <div className="flex items-start">
-                          <AlertTriangle
-                            className={`mr-3 mt-0.5 h-5 w-5 ${
-                              alert.level === "critical"
-                                ? "text-red-500"
-                                : alert.level === "warning"
-                                  ? "text-yellow-500"
-                                  : "text-blue-500"
-                            }`}
-                          />
-                          <div>
-                            <p className="font-medium text-gray-900 dark:text-gray-100">
-                              {alert.message}
-                            </p>
-                            <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-                              {new Date(alert.timestamp).toLocaleString()}
-                            </p>
-                          </div>
-                        </div>
-                        <span
-                          className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
-                            alert.level === "critical"
-                              ? "bg-red-100 text-red-800 dark:bg-red-900/20 dark:text-red-300"
-                              : alert.level === "warning"
-                                ? "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/20 dark:text-yellow-300"
-                                : "bg-blue-100 text-blue-800 dark:bg-blue-900/20 dark:text-blue-300"
-                          }`}
-                        >
-                          {alert.level}
-                        </span>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {/* Recent Logs */}
-            <div className="mb-8">
-              <h2 className="mb-4 text-xl font-semibold text-gray-900 dark:text-gray-100">
-                Recent Activity
-              </h2>
-              <div className="rounded-lg border border-gray-200 bg-white shadow dark:border-gray-700 dark:bg-gray-800">
-                <div className="max-h-64 overflow-y-auto">
-                  {monitoringData.recentLogs.map((log, index) => (
-                    <div
-                      key={index}
-                      className="border-b border-gray-200 p-4 last:border-b-0 dark:border-gray-700"
-                    >
-                      <div className="flex items-start justify-between">
-                        <div className="flex items-start">
                           <span
-                            className={`mr-3 mt-2 inline-block h-2 w-2 rounded-full ${
-                              log.level === "error"
-                                ? "bg-red-500"
-                                : log.level === "warn"
-                                  ? "bg-yellow-500"
-                                  : log.level === "info"
-                                    ? "bg-blue-500"
-                                    : "bg-gray-500"
-                            }`}
-                          />
-                          <div>
-                            <p className="text-sm text-gray-900 dark:text-gray-100">
-                              {log.message}
-                            </p>
-                            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                              {log.source} •{" "}
-                              {new Date(log.timestamp).toLocaleString()}
-                            </p>
-                          </div>
+                            className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${alert.level === "critical"
+                                ? "bg-red-100 text-red-800 dark:bg-red-900/20 dark:text-red-300"
+                                : alert.level === "warning"
+                                  ? "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/20 dark:text-yellow-300"
+                                  : "bg-blue-100 text-blue-800 dark:bg-blue-900/20 dark:text-blue-300"
+                              }`}
+                          >
+                            {alert.level}
+                          </span>
                         </div>
-                        <span
-                          className={`inline-flex items-center rounded px-2 py-1 text-xs font-medium ${
-                            log.level === "error"
-                              ? "bg-red-100 text-red-800 dark:bg-red-900/20 dark:text-red-300"
-                              : log.level === "warn"
-                                ? "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/20 dark:text-yellow-300"
-                                : log.level === "info"
-                                  ? "bg-blue-100 text-blue-800 dark:bg-blue-900/20 dark:text-blue-300"
-                                  : "bg-gray-100 text-gray-800 dark:bg-gray-900/20 dark:text-gray-300"
-                          }`}
-                        >
-                          {log.level}
-                        </span>
                       </div>
-                    </div>
-                  ))}
+                    ))}
+                  </div>
                 </div>
-              </div>
-            </div>
+              )}
 
-            {/* Recommendations */}
-            {monitoringData.recommendations.length > 0 && (
+              {/* Recent Logs */}
               <div className="mb-8">
                 <h2 className="mb-4 text-xl font-semibold text-gray-900 dark:text-gray-100">
-                  Recommendations
+                  Recent Activity
                 </h2>
-                <div className="rounded-lg border border-blue-200 bg-blue-50 p-6 dark:border-blue-700 dark:bg-blue-900/20">
-                  <ul className="space-y-2">
-                    {monitoringData.recommendations.map(
-                      (recommendation, index) => (
-                        <li key={index} className="flex items-start">
-                          <span className="mr-2 text-blue-500">•</span>
-                          <span className="text-blue-800 dark:text-blue-300">
-                            {recommendation}
+                <div className="rounded-lg border border-gray-200 bg-white shadow dark:border-gray-700 dark:bg-gray-800">
+                  <div className="max-h-64 overflow-y-auto">
+                    {monitoringData.recentLogs.map((log, index) => (
+                      <div
+                        key={index}
+                        className="border-b border-gray-200 p-4 last:border-b-0 dark:border-gray-700"
+                      >
+                        <div className="flex items-start justify-between">
+                          <div className="flex items-start">
+                            <span
+                              className={`mr-3 mt-2 inline-block h-2 w-2 rounded-full ${log.level === "error"
+                                  ? "bg-red-500"
+                                  : log.level === "warn"
+                                    ? "bg-yellow-500"
+                                    : log.level === "info"
+                                      ? "bg-blue-500"
+                                      : "bg-gray-500"
+                                }`}
+                            />
+                            <div>
+                              <p className="text-sm text-gray-900 dark:text-gray-100">
+                                {log.message}
+                              </p>
+                              <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                                {log.source} •{" "}
+                                {new Date(log.timestamp).toLocaleString()}
+                              </p>
+                            </div>
+                          </div>
+                          <span
+                            className={`inline-flex items-center rounded px-2 py-1 text-xs font-medium ${log.level === "error"
+                                ? "bg-red-100 text-red-800 dark:bg-red-900/20 dark:text-red-300"
+                                : log.level === "warn"
+                                  ? "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/20 dark:text-yellow-300"
+                                  : log.level === "info"
+                                    ? "bg-blue-100 text-blue-800 dark:bg-blue-900/20 dark:text-blue-300"
+                                    : "bg-gray-100 text-gray-800 dark:bg-gray-900/20 dark:text-gray-300"
+                              }`}
+                          >
+                            {log.level}
                           </span>
-                        </li>
-                      ),
-                    )}
-                  </ul>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
                 </div>
               </div>
-            )}
-          </>
-        )}
-      </main>
-    </div>
+
+              {/* Recommendations */}
+              {monitoringData.recommendations.length > 0 && (
+                <div className="mb-8">
+                  <h2 className="mb-4 text-xl font-semibold text-gray-900 dark:text-gray-100">
+                    Recommendations
+                  </h2>
+                  <div className="rounded-lg border border-blue-200 bg-blue-50 p-6 dark:border-blue-700 dark:bg-blue-900/20">
+                    <ul className="space-y-2">
+                      {monitoringData.recommendations.map(
+                        (recommendation, index) => (
+                          <li key={index} className="flex items-start">
+                            <span className="mr-2 text-blue-500">•</span>
+                            <span className="text-blue-800 dark:text-blue-300">
+                              {recommendation}
+                            </span>
+                          </li>
+                        ),
+                      )}
+                    </ul>
+                  </div>
+                </div>
+              )}
+            </>
+          )}
+        </main>
+      </div>
+    </>
   );
 }
 

--- a/src/routes/pending-approval.tsx
+++ b/src/routes/pending-approval.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+/**
+ * หน้า Pending Approval
+ * แสดงเมื่อผู้ใช้ Login ด้วย LINE แต่ยังไม่ได้รับการอนุมัติ
+ * ให้ทราบว่าต้องรอการอนุมัติจาก admin
+ */
+import { createFileRoute } from "@tanstack/react-router";
+import { useSession } from "@/lib/auth/client";
+import { useNavigate } from "@tanstack/react-router";
+import { useEffect } from "react";
+import { Clock, MessageSquare, ShieldCheck } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+function PendingApprovalPage() {
+  const { data: session, status } = useSession();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (status === "unauthenticated") {
+      void navigate({ to: "/" });
+    }
+  }, [status, navigate]);
+
+  if (status === "loading") {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <p className="text-muted-foreground">กำลังโหลด...</p>
+      </div>
+    );
+  }
+
+  if (!session) {
+    return null;
+  }
+
+  return (
+    <div className="bg-background flex min-h-screen items-center justify-center p-4">
+      <div className="border-border bg-card max-w-md w-full rounded-xl border p-8 text-center shadow-lg">
+        {/* Icon */}
+        <div className="mx-auto mb-6 flex h-20 w-20 items-center justify-center rounded-full bg-amber-100 text-amber-600 dark:bg-amber-900/30">
+          <Clock className="h-10 w-10" />
+        </div>
+
+        {/* Heading */}
+        <h1 className="text-foreground mb-3 text-2xl font-bold">
+          รอการอนุมัติ
+        </h1>
+
+        {/* Message */}
+        <p className="text-muted-foreground mb-6 text-sm leading-relaxed">
+          บัญชี LINE ของคุณยังไม่ได้รับการอนุมัติให้ใช้งาน
+          <br />
+          กรุณารอสัญญา่ admin เพื่อขออนุมัติใช้งาน
+        </p>
+
+        {/* Info */}
+        <div className="border-border bg-muted/50 mb-8 rounded-lg border p-4 text-left">
+          <div className="mb-3 flex items-start gap-3">
+            <MessageSquare className="text-primary h-5 w-5 shrink-0" />
+            <div>
+              <p className="text-foreground font-medium text-sm">
+                อะไรบ้างที่ต้องการอนุมัติ?
+              </p>
+              <p className="text-muted-foreground mt-1 text-xs">
+                LINE Messaging API: ส่งคำสั่งผ่าน LINE Bot
+              </p>
+            </div>
+          </div>
+          <div className="flex items-start gap-3">
+            <ShieldCheck className="text-primary h-5 w-5 shrink-0" />
+            <div>
+              <p className="text-foreground font-medium text-sm">
+                ผู้อนุมัติบางคน?
+              </p>
+              <p className="text-muted-foreground mt-1 text-xs">
+                Admin จะตรวจสอบและอนุมัติคำของของคุณ
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="flex flex-col gap-3">
+          <Button
+            onClick={() => void navigate({ to: "/dashboard" })}
+            variant="outline"
+            className="w-full"
+          >
+            กลับหน้าหลัก
+          </Button>
+          <Button
+            onClick={() => void navigate({ to: "/logout" })}
+            variant="ghost"
+            className="w-full"
+          >
+            ออกจากระบบ
+          </Button>
+        </div>
+
+        {/* Help text */}
+        <p className="text-muted-foreground mt-6 text-xs">
+          หากมีข้อสงสัย หรือต้องการติดต่อ admin โปรดติดต่อทีมงาน
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export const Route = createFileRoute("/pending-approval")({
+  component: PendingApprovalPage,
+});


### PR DESCRIPTION
## Summary

- Add `LineApprovalGuard` component and `withLineApproval` HOC to block unapproved LINE users from protected pages
- Add `useLineApproval` hook that calls `/api/auth/check-line-approval` and exposes `isLoading`, `needsApproval`, `hasLineAccount`
- Add `/api/auth/check-line-approval` server endpoint backed by `approval-guard.ts` utility
- Add `/pending-approval` route — landing page for users with PENDING or REJECTED status
- Add `PendingApprovalModal` UI component for inline blocking when approval is required
- Add `unlockRejectedUser` in `approvalService` to reset REJECTED → PENDING so users can re-apply
- Wrap all protected routes (dashboard, leave, attendance-report, dca-history, monitoring, line-approval) with approval guard
- Apply approval enforcement to cron routes (auto-checkout, check-in-reminder, checkout-reminder, enhanced-checkout-reminder)

## Test plan

- [ ] Login with a LINE account that has `PENDING` status → should redirect to `/pending-approval`
- [ ] Login with a LINE account that has `REJECTED` status → should redirect to `/pending-approval`
- [ ] Login with a LINE account that has `APPROVED` status → should pass through to the requested page normally
- [ ] Login without a LINE account → should pass through (non-LINE users are not gated)
- [ ] Admin unlocks a rejected user via `unlockRejectedUser` → status becomes `PENDING`, user can re-request
- [ ] `/api/auth/check-line-approval` returns `{ approved: true }` for approved users, `{ approved: false }` for pending/rejected
- [ ] Cron routes return 401/403 for unapproved callers
- [ ] `PendingApprovalModal` renders correctly in light and dark mode