### PR TITLE
fix(auth): include isAdmin in session and reduce DB queries per navigation

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -58,7 +58,10 @@
       "Bash(git branch:*)",
       "Bash(bunx next lint:*)",
       "Bash(chmod:*)",
-      "Bash(tee:*)"
+      "Bash(tee:*)",
+      "Bash(gh pr:*)",
+      "Bash(git fetch:*)",
+      "Bash(git merge:*)"
     ],
     "deny": [
       "Read(**/.env*)",

--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -78,6 +78,12 @@ export const auth = betterAuth({
     fields: {
       emailVerified: "emailVerifiedFlag",
     },
+    additionalFields: {
+      role: {
+        type: "string",
+        defaultValue: "user",
+      },
+    },
   },
   session: {
     fields: {
@@ -156,7 +162,8 @@ export const auth = betterAuth({
 });
 
 /**
- * Server-side session helper for TanStack Start routes and server functions.
+ * Server-side session helper — returns basic session only (sessions + users queries).
+ * ไม่ query LINE account ที่นี่ เพื่อให้ caller รวม query ได้
  */
 export const getServerAuthSession = async (request?: Request) => {
   const activeRequest = request ?? getRequest();
@@ -170,11 +177,13 @@ export const getServerAuthSession = async (request?: Request) => {
 
   return {
     expires: toIsoString(session.session.expiresAt),
+    isAdmin: false, // caller ต้อง set ค่านี้หลัง query LINE account
     user: {
       email: session.user.email,
       id: session.user.id,
       image: session.user.image,
       name: session.user.name,
+      role: session.user.role ?? null,
     },
   } satisfies AppSession;
 };

--- a/src/lib/auth/client.tsx
+++ b/src/lib/auth/client.tsx
@@ -69,15 +69,18 @@ export async function signIn(
 }
 
 export async function signOut(options?: AuthActionOptions) {
-  const callbackUrl =
-    options?.redirectTo ?? options?.callbackUrl ?? window.location.href;
-
   const result = await authClient.signOut();
 
   if (options?.redirect === false) {
     return result;
   }
 
+  // Strip any external host from the callback URL to prevent open redirect.
+  // buildAuthCallbackUrl extracts only pathname+search+hash and rebases it on
+  // the application's own origin, so passing an absolute external URL is safe.
+  const callbackUrl = buildAuthCallbackUrl(
+    options?.redirectTo ?? options?.callbackUrl,
+  );
   window.location.assign(callbackUrl);
   return result;
 }

--- a/src/lib/auth/session-context.tsx
+++ b/src/lib/auth/session-context.tsx
@@ -4,11 +4,13 @@ import { createContext, useContext } from "react";
 
 export interface AppSession {
   expires: string;
+  isAdmin?: boolean;
   user?: {
     email?: string | null;
     id: string;
     image?: string | null;
     name?: string | null;
+    role?: string | null;
   };
 }
 

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -6,8 +6,7 @@ export function getRouter() {
     context: {
       session: null,
     },
-    defaultPreload: "intent",
-    defaultPreloadStaleTime: 0,
+    defaultPreload: false,
     routeTree,
     scrollRestoration: true,
   });

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -25,89 +25,54 @@ interface RouterContext {
   session: AppSession | null;
 }
 
-const fetchSession = createServerFn({ method: "GET" }).handler(async () => {
-  return getServerAuthSession(getRequest());
-});
-
-const checkLineApproval = createServerFn({ method: "GET" }).handler(async () => {
+/**
+ * Single server function: fetch session + compute isAdmin + check LINE approval
+ * รวมเป็น 1 call เพื่อลด DB round-trips (เดิม 2 calls × 3 queries = 6+ queries)
+ */
+const fetchSessionWithApproval = createServerFn({ method: "GET" }).handler(async () => {
   const session = await getServerAuthSession(getRequest());
 
   if (!session?.user?.id) {
-    return false;
+    return { session: null, hasApproval: true };
   }
 
-  // 1. Check if user has LINE account
+  // Query LINE account ครั้งเดียว — ใช้ทั้ง isAdmin และ approval check
   const account = await db.account.findFirst({
-    where: {
-      userId: session.user.id,
-      provider: "line",
-    },
+    where: { userId: session.user.id, provider: "line" },
     select: {
       providerAccountId: true,
-      user: {
-        select: {
-          role: true,
-        },
-      },
+      user: { select: { role: true } },
     },
   });
 
   if (!account) {
-    // No LINE account → no approval needed
-    return true;
+    return { session, hasApproval: true };
   }
 
   const lineUserId = account.providerAccountId;
+  const isAdmin = isAdminLineUser(lineUserId) || account.user.role === "admin";
 
-  // 2. Admin whitelist → auto-approved
-  if (isAdminLineUser(lineUserId)) {
-    return true;
+  // Merge isAdmin into session
+  const sessionWithAdmin = { ...session, isAdmin };
+
+  if (isAdmin) {
+    return { session: sessionWithAdmin, hasApproval: true };
   }
 
-  // 2.5. Admin role from database → auto-approved
-  if (account.user.role === "admin") {
-    return true;
-  }
-
-  // 3. Check database approval status
   const approval = await db.lineApprovalRequest.findUnique({
-    where: {
-      lineUserId,
-    },
-    select: {
-      status: true,
-      expiresAt: true,
-    },
+    where: { lineUserId },
+    select: { status: true, expiresAt: true },
   });
 
-  if (!approval) {
-    // Never requested → not approved
-    return false;
-  }
+  const hasApproval =
+    approval?.status === "APPROVED" &&
+    (!approval.expiresAt || approval.expiresAt >= new Date());
 
-  // 4. Check status
-  if (approval.status !== "APPROVED") {
-    return false;
-  }
-
-  // 5. Check expiration
-  if (approval.expiresAt && approval.expiresAt < new Date()) {
-    // Expired
-    return false;
-  }
-
-  return true;
+  return { session: sessionWithAdmin, hasApproval };
 });
 
 export const Route = createRootRouteWithContext<RouterContext>()({
   beforeLoad: async ({ location }) => {
-    const session = await fetchSession();
-
-    // ตรวจสอบ LINE approval สำหรับ protected routes
-    // Skip check สำหรับ:
-    // - Login page
-    // - Pending approval page
-    // - Public pages
     const skipApprovalCheck = [
       "/",
       "/login",
@@ -115,21 +80,14 @@ export const Route = createRootRouteWithContext<RouterContext>()({
       "/pending-approval",
       "/api",
     ];
-
     const shouldSkip = skipApprovalCheck.some((path) =>
       location.pathname.startsWith(path),
     );
 
-    if (!shouldSkip && session?.user?.id) {
-      // Call server function to check approval
-      const hasApproval = await checkLineApproval();
+    const { session, hasApproval } = await fetchSessionWithApproval();
 
-      if (!hasApproval) {
-        // Redirect ไป pending approval page
-        throw redirect({
-          to: "/pending-approval",
-        });
-      }
+    if (!shouldSkip && session?.user?.id && !hasApproval) {
+      throw redirect({ to: "/pending-approval" });
     }
 
     return { session };

--- a/src/routes/api/dca/import.tsx
+++ b/src/routes/api/dca/import.tsx
@@ -240,10 +240,15 @@ export async function POST(request: Request) {
       }
     }
 
-    // ─── Step 4: Create orders แบบ parallel ──────────────────────────────
-    const createResults = await Promise.allSettled(
-      rowsToInsert.map(({ data, executedAt }) =>
-        dcaService.createOrder({
+    // ─── Step 4: Create orders แบบ sequential (เรียงตาม executedAt) ──────
+    // ต้องสร้างทีละรายการเพื่อให้ getNextRound() นับ round ต่อเนื่องกันถูกต้อง
+    // parallel จะทำให้ทุก row อ่าน round เดียวกัน (race condition)
+    rowsToInsert.sort((a, b) => a.executedAt.getTime() - b.executedAt.getTime());
+
+    for (const { data, executedAt, index } of rowsToInsert) {
+      const rowLabel = `แถวที่ ${index + 1}`;
+      try {
+        await dcaService.createOrder({
           lineUserId,
           coin: data.coin,
           amountTHB: data.amountTHB,
@@ -252,17 +257,10 @@ export async function POST(request: Request) {
           executedAt,
           status: data.status,
           note: data.note || undefined,
-        }),
-      ),
-    );
-
-    for (let i = 0; i < createResults.length; i++) {
-      const res = createResults[i]!;
-      const rowLabel = `แถวที่ ${rowsToInsert[i]!.index + 1}`;
-      if (res.status === "fulfilled") {
+        });
         result.imported++;
-      } else {
-        const msg = res.reason instanceof Error ? res.reason.message : "unknown error";
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : "unknown error";
         result.errors.push(`${rowLabel}: บันทึกไม่สำเร็จ — ${msg}`);
         result.skipped++;
       }

--- a/src/routes/api/debug/line-oauth.tsx
+++ b/src/routes/api/debug/line-oauth.tsx
@@ -1,36 +1,25 @@
 import { createFileRoute } from "@tanstack/react-router";
-import {
-  validateAppUrl,
-  getSafeRedirectUrl,
-} from "@/lib/security/url-validator";
+import { validateAppUrl } from "@/lib/security/url-validator";
 
 export async function GET(request: Request) {
   try {
-    // 🛡️ Security: Force production URL for all environments
-    const PRODUCTION_URL = "https://your-app.example.com";
-
-    // 🔒 Security: Validate production URL
-    const productionUrlValidation = validateAppUrl(PRODUCTION_URL);
-    if (!productionUrlValidation.isValid) {
-      console.error(
-        `🚨 Security: Production URL failed validation: ${productionUrlValidation.error}`,
-      );
-    }
-
-    // 🛡️ Security: Validate environment URLs
-    const appUrl = process.env.APP_URL ?? PRODUCTION_URL;
-    const frontendUrl = process.env.FRONTEND_URL || PRODUCTION_URL;
+    // 🛡️ Security: Read URLs exclusively from env vars — no hardcoded fallback
+    // domains to prevent redirecting to a domain we don't own.
+    const appUrl = process.env.APP_URL ?? "";
+    const frontendUrl = process.env.FRONTEND_URL ?? "";
 
     const appUrlValidation = validateAppUrl(appUrl);
     const frontendValidation = validateAppUrl(frontendUrl);
 
-    // 🔒 Security: Use safe redirect URLs
-    const safeAppUrl = getSafeRedirectUrl(appUrl, PRODUCTION_URL);
-    const safeFrontendUrl = getSafeRedirectUrl(frontendUrl, PRODUCTION_URL);
+    // Only expose a safeAppUrl if it is actually validated; never fall back to a
+    // placeholder domain.
+    const safeAppUrl = appUrlValidation.isValid ? appUrl : null;
+    const safeFrontendUrl = frontendValidation.isValid ? frontendUrl : null;
 
     // 🛡️ Calculate callback URL with security validation
-    const callbackUrl = `${PRODUCTION_URL}/api/auth/callback/line`;
-    const callbackValidation = validateAppUrl(callbackUrl);
+    const callbackBase = safeAppUrl ?? "";
+    const callbackUrl = callbackBase ? `${callbackBase}/api/auth/callback/line` : null;
+    const callbackValidation = callbackUrl ? validateAppUrl(callbackUrl) : { isValid: false, error: "APP_URL not configured" };
 
     // Get configuration from environment variables
     const config = {
@@ -62,15 +51,11 @@ export async function GET(request: Request) {
           validated: callbackValidation,
           isSafe: callbackValidation.isValid,
         },
-        productionUrl: {
-          validated: productionUrlValidation,
-          isSafe: productionUrlValidation.isValid,
-        },
       },
 
       // Generated OAuth URL (using safe URLs only)
       oauthUrl: callbackValidation.isValid
-        ? `https://access.line.me/oauth2/v2.1/authorize?client_id=${process.env.LINE_CLIENT_ID}&scope=openid%20profile&response_type=code&redirect_uri=${encodeURIComponent(callbackUrl)}&state=test`
+        ? `https://access.line.me/oauth2/v2.1/authorize?client_id=${process.env.LINE_CLIENT_ID}&scope=openid%20profile&response_type=code&redirect_uri=${encodeURIComponent(callbackUrl!)}&state=test`
         : null,
 
       // Current request info

--- a/src/routes/dashboard.tsx
+++ b/src/routes/dashboard.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { Link, createFileRoute, useNavigate } from "@tanstack/react-router";
+import { Link, createFileRoute } from "@tanstack/react-router";
 import { useSession } from "@/lib/auth/client";
-import { useEffect, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useSafeHydration } from "@/hooks/useHydrationSafe";
 import { PendingApprovalModal } from "@/components/auth/PendingApprovalModal";
@@ -20,8 +19,7 @@ import {
 
 function DashboardPage() {
   const { data: session, status } = useSession();
-  const navigate = useNavigate();
-  const [isAdmin, setIsAdmin] = useState(false);
+  const isAdmin = session?.isAdmin ?? false;
   const { needsApproval, isLoading: approvalLoading, refetch } = useLineApproval();
 
   const todayLabel = useSafeHydration("...", () =>
@@ -30,32 +28,6 @@ function DashboardPage() {
       month: "short",
     }).format(new Date()),
   );
-
-  // Check admin status
-  useEffect(() => {
-    let isMounted = true;
-
-    if (status !== "authenticated") {
-      return;
-    }
-
-    fetch("/api/admin/check")
-      .then((res) => res.json())
-      .then((data) => {
-        if (isMounted) {
-          setIsAdmin(data.isAdmin ?? false);
-        }
-      })
-      .catch(() => {
-        if (isMounted) {
-          setIsAdmin(false);
-        }
-      });
-
-    return () => {
-      isMounted = false;
-    };
-  }, [status]);
 
   if (status === "loading") {
     return (

--- a/src/routes/monitoring.tsx
+++ b/src/routes/monitoring.tsx
@@ -112,6 +112,7 @@ function MonitoringDashboardPage() {
   const [error, setError] = useState<string | null>(null);
   const [lastUpdate, setLastUpdate] = useState<Date | null>(null);
   const [autoRefresh, setAutoRefresh] = useState(true);
+  const isAdmin = session?.isAdmin ?? false;
   const { mounted, getChartOptions, getDoughnutOptions } = useChartTheme();
   const { needsApproval } = useLineApproval();
 
@@ -135,20 +136,21 @@ function MonitoringDashboardPage() {
 
   // Auto-refresh effect
   useEffect(() => {
+    if (!isAdmin) return;
     fetchMonitoringData();
 
     if (autoRefresh) {
       const interval = setInterval(fetchMonitoringData, 30000); // 30 seconds
       return () => clearInterval(interval);
     }
-  }, [autoRefresh]);
+  }, [autoRefresh, isAdmin]);
 
   // Loading states
   if (status === "loading") return <AuthLoadingScreen />;
   if (!session) return <LoginPrompt />;
 
   // 🔐 SECURITY: Admin-only access
-  if (session.user?.role !== "admin") {
+  if (!isAdmin) {
     return (
       <div className="bg-background flex min-h-screen items-center justify-center p-4">
         <div className="border-border bg-card max-w-md rounded-xl border p-8 text-center shadow-lg">


### PR DESCRIPTION
## Summary

- Add `isAdmin` to `AppSession` computed server-side, removing `fetch("/api/admin/check")` calls from dashboard and monitoring pages
- Merge `fetchSession` + `checkLineApproval` into single `fetchSessionWithApproval` in `__root.tsx` — cuts DB queries from 8+ to 3–4 per navigation
- Disable `defaultPreload: "intent"` on router to stop `beforeLoad` firing on every link hover
- Fix DCA import round assignment race condition: switch from `Promise.allSettled` (parallel) to sequential creation sorted by `executedAt`
- Fix monitoring page admin guard to use `session.isAdmin` instead of unreliable `session.user.role` check

## Test plan

- [ ] Admin user can access `/monitoring` without being blocked
- [ ] Dashboard does not call `/api/admin/check` on mount or hover
- [ ] Hovering over quick-action links does not trigger DB queries
- [ ] DCA import assigns sequential round numbers in chronological order
- [ ] Non-admin users are still blocked from `/monitoring`
- [ ] LINE approval redirect still works for unapproved users