### PR TITLE
fix(auth): use cookie storeStateStrategy to fix LINE Login in production

### DIFF
--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -122,7 +122,9 @@ export const auth = betterAuth({
     },
   },
   account: {
-    skipStateCookieCheck: env.APP_ENV === "development",
+    // ใช้ "cookie" strategy เพื่อเก็บ OAuth state ใน encrypted cookie แทน DB + signed cookie
+    // แก้ปัญหา tanstackStartCookies ไม่สามารถ forward signed cookie ได้ถูกต้องใน production
+    storeStateStrategy: "cookie",
     fields: {
       accountId: "providerAccountId",
       providerId: "provider",


### PR DESCRIPTION
## Summary

- LINE Login OAuth callback was failing in production due to state verification errors
- Root cause: `tanstackStartCookies` could not correctly forward signed cookies in production, causing the OAuth state check to fail
- Fix: replaced `skipStateCookieCheck` (development-only workaround) with `storeStateStrategy: "cookie"`, which stores OAuth state in an encrypted cookie instead of the database + signed cookie flow
- This resolves the issue without bypassing security checks and works correctly in both development and production

## Testing

- Verify LINE Login completes successfully in production (full OAuth callback without state mismatch error)
- Verify LINE Login still works in development environment
- Confirm no regression in other OAuth providers if configured
- Check that the encrypted state cookie is set and cleared correctly during the login flow