### PR TITLE
fix(auth): stabilize LINE Login callback in production

### DIFF
--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -122,9 +122,10 @@ export const auth = betterAuth({
     },
   },
   account: {
-    // ใช้ "cookie" strategy เพื่อเก็บ OAuth state ใน encrypted cookie แทน DB + signed cookie
-    // แก้ปัญหา tanstackStartCookies ไม่สามารถ forward signed cookie ได้ถูกต้องใน production
-    storeStateStrategy: "cookie",
+    // เก็บ OAuth state ใน DB เพื่อให้ LINE callback ยังทำงานได้เมื่อ browser/webview
+    // ที่เริ่ม login กับ browser ที่รับ callback ไม่ได้แชร์ OAuth state cookie กัน
+    storeStateStrategy: "database",
+    skipStateCookieCheck: true,
     fields: {
       accountId: "providerAccountId",
       providerId: "provider",

--- a/src/lib/auth/client.tsx
+++ b/src/lib/auth/client.tsx
@@ -12,10 +12,14 @@ interface AuthActionOptions {
 export const authClient = createAuthClient();
 
 function getAuthOrigin() {
-  try {
-    return __APP_URL__ ? new URL(__APP_URL__).origin : window.location.origin;
-  } catch {
+  if (typeof window !== "undefined") {
     return window.location.origin;
+  }
+
+  try {
+    return __APP_URL__ ? new URL(__APP_URL__).origin : "";
+  } catch {
+    return "";
   }
 }
 


### PR DESCRIPTION
## Summary
- store Better Auth OAuth state in the database for LINE callback reliability across browser/webview redirects
- use the current browser origin for auth callback URLs to avoid stale build-time production domains

## Verification
- bun run type-check
- bun run build

## Notes
- Production debug currently reports APP_URL and callback URL as Prod URLs /api/auth/callback/line.
