### PR TITLE
fix(auth): use server redirect for LINE sign-in

### DIFF
--- a/src/lib/auth/client.tsx
+++ b/src/lib/auth/client.tsx
@@ -65,6 +65,13 @@ export async function signIn(
     options?.redirectTo ?? options?.callbackUrl,
   );
 
+  if (provider === "line" && options?.redirect !== false) {
+    const signInUrl = new URL("/api/auth/sign-in/line", window.location.origin);
+    signInUrl.searchParams.set("callbackURL", callbackUrl);
+    window.location.assign(signInUrl.toString());
+    return;
+  }
+
   return authClient.signIn.social({
     callbackURL: callbackUrl,
     disableRedirect: options?.redirect === false,

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -63,6 +63,7 @@ import { Route as ApiAttendanceUpdateRouteImport } from './routes/api/attendance
 import { Route as ApiAdminDebugRouteImport } from './routes/api/admin/debug'
 import { Route as ApiAdminCheckRouteImport } from './routes/api/admin/check'
 import { Route as ApiUserSettingsNotificationsRouteImport } from './routes/api/user/settings/notifications'
+import { Route as ApiAuthSignInLineRouteImport } from './routes/api/auth/sign-in/line'
 
 const ThaiNamesGeneratorRoute = ThaiNamesGeneratorRouteImport.update({
   id: '/thai-names-generator',
@@ -342,6 +343,11 @@ const ApiUserSettingsNotificationsRoute =
     path: '/notifications',
     getParentRoute: () => ApiUserSettingsRoute,
   } as any)
+const ApiAuthSignInLineRoute = ApiAuthSignInLineRouteImport.update({
+  id: '/api/auth/sign-in/line',
+  path: '/api/auth/sign-in/line',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -397,6 +403,7 @@ export interface FileRoutesByFullPath {
   '/api/user/settings': typeof ApiUserSettingsRouteWithChildren
   '/api/dca/': typeof ApiDcaIndexRoute
   '/api/subscriptions/': typeof ApiSubscriptionsIndexRoute
+  '/api/auth/sign-in/line': typeof ApiAuthSignInLineRoute
   '/api/user/settings/notifications': typeof ApiUserSettingsNotificationsRoute
 }
 export interface FileRoutesByTo {
@@ -453,6 +460,7 @@ export interface FileRoutesByTo {
   '/api/user/settings': typeof ApiUserSettingsRouteWithChildren
   '/api/dca': typeof ApiDcaIndexRoute
   '/api/subscriptions': typeof ApiSubscriptionsIndexRoute
+  '/api/auth/sign-in/line': typeof ApiAuthSignInLineRoute
   '/api/user/settings/notifications': typeof ApiUserSettingsNotificationsRoute
 }
 export interface FileRoutesById {
@@ -510,6 +518,7 @@ export interface FileRoutesById {
   '/api/user/settings': typeof ApiUserSettingsRouteWithChildren
   '/api/dca/': typeof ApiDcaIndexRoute
   '/api/subscriptions/': typeof ApiSubscriptionsIndexRoute
+  '/api/auth/sign-in/line': typeof ApiAuthSignInLineRoute
   '/api/user/settings/notifications': typeof ApiUserSettingsNotificationsRoute
 }
 export interface FileRouteTypes {
@@ -568,6 +577,7 @@ export interface FileRouteTypes {
     | '/api/user/settings'
     | '/api/dca/'
     | '/api/subscriptions/'
+    | '/api/auth/sign-in/line'
     | '/api/user/settings/notifications'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -624,6 +634,7 @@ export interface FileRouteTypes {
     | '/api/user/settings'
     | '/api/dca'
     | '/api/subscriptions'
+    | '/api/auth/sign-in/line'
     | '/api/user/settings/notifications'
   id:
     | '__root__'
@@ -680,6 +691,7 @@ export interface FileRouteTypes {
     | '/api/user/settings'
     | '/api/dca/'
     | '/api/subscriptions/'
+    | '/api/auth/sign-in/line'
     | '/api/user/settings/notifications'
   fileRoutesById: FileRoutesById
 }
@@ -734,6 +746,7 @@ export interface RootRouteChildren {
   ApiUserSettingsRoute: typeof ApiUserSettingsRouteWithChildren
   ApiDcaIndexRoute: typeof ApiDcaIndexRoute
   ApiSubscriptionsIndexRoute: typeof ApiSubscriptionsIndexRoute
+  ApiAuthSignInLineRoute: typeof ApiAuthSignInLineRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -1116,6 +1129,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiUserSettingsNotificationsRouteImport
       parentRoute: typeof ApiUserSettingsRoute
     }
+    '/api/auth/sign-in/line': {
+      id: '/api/auth/sign-in/line'
+      path: '/api/auth/sign-in/line'
+      fullPath: '/api/auth/sign-in/line'
+      preLoaderRoute: typeof ApiAuthSignInLineRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -1207,6 +1227,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiUserSettingsRoute: ApiUserSettingsRouteWithChildren,
   ApiDcaIndexRoute: ApiDcaIndexRoute,
   ApiSubscriptionsIndexRoute: ApiSubscriptionsIndexRoute,
+  ApiAuthSignInLineRoute: ApiAuthSignInLineRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routes/api/auth/sign-in/line.tsx
+++ b/src/routes/api/auth/sign-in/line.tsx
@@ -1,0 +1,89 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { auth } from "@/lib/auth";
+import { env } from "@/env.mjs";
+
+const getPublicOrigin = () => new URL(env.APP_URL).origin;
+
+const getSafeCallbackUrl = (request: Request) => {
+  const publicOrigin = getPublicOrigin();
+  const requestUrl = new URL(request.url);
+  const rawCallbackUrl = requestUrl.searchParams.get("callbackURL") ?? "/";
+
+  try {
+    const callbackUrl = new URL(rawCallbackUrl, publicOrigin);
+
+    if (callbackUrl.origin !== publicOrigin) {
+      return publicOrigin;
+    }
+
+    return callbackUrl.toString();
+  } catch {
+    return publicOrigin;
+  }
+};
+
+const copySetCookieHeaders = (from: Headers, to: Headers) => {
+  const getSetCookie = (from as Headers & { getSetCookie?: () => string[] })
+    .getSetCookie;
+  const cookies =
+    typeof getSetCookie === "function"
+      ? getSetCookie.call(from)
+      : [from.get("set-cookie")].filter((cookie): cookie is string =>
+          Boolean(cookie),
+        );
+
+  for (const cookie of cookies) {
+    to.append("set-cookie", cookie);
+  }
+};
+
+const handleLineSignIn = async (request: Request) => {
+  const publicOrigin = getPublicOrigin();
+  const callbackURL = getSafeCallbackUrl(request);
+  const signInUrl = new URL("/api/auth/sign-in/social", publicOrigin);
+
+  const signInResponse = await auth.handler(
+    new Request(signInUrl, {
+      body: JSON.stringify({
+        callbackURL,
+        provider: "line",
+      }),
+      headers: {
+        "content-type": "application/json",
+        origin: publicOrigin,
+      },
+      method: "POST",
+    }),
+  );
+
+  const result = (await signInResponse.json()) as {
+    redirect?: boolean;
+    url?: string;
+  };
+
+  if (!result.url) {
+    return Response.redirect(
+      new URL("/login?error=line_login_failed", publicOrigin),
+      302,
+    );
+  }
+
+  const headers = new Headers({
+    "cache-control": "no-store",
+    location: result.url,
+  });
+  copySetCookieHeaders(signInResponse.headers, headers);
+
+  return new Response(null, {
+    headers,
+    status: 302,
+  });
+};
+
+export const Route = createFileRoute("/api/auth/sign-in/line")({
+  server: {
+    handlers: {
+      GET: ({ request }) => handleLineSignIn(request),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add a server-side LINE sign-in route that asks Better Auth to create OAuth state, then returns a real 302 to LINE
- update the LINE login client action to navigate to that route instead of relying on Better Auth client-side fetch redirect
- include generated TanStack route tree updates

## Why
The failing prod callback reaches Better Auth with `please_restart_the_process`, which is thrown while parsing OAuth state before the LINE code is exchanged. A full-page server redirect keeps the state creation and provider navigation in one top-level HTTP flow and avoids browser/webview iframe or client redirect issues.

## Verification
- bun run type-check
- bun run build
- local built server: GET /api/auth/sign-in/line returned 302 to access.line.me with Better Auth state and PKCE code_challenge
