### PR TITLE
fix(auth): recover stale LINE OAuth state

### DIFF
--- a/src/lib/auth/client.tsx
+++ b/src/lib/auth/client.tsx
@@ -64,6 +64,7 @@ export async function signIn(
   return authClient.signIn.social({
     callbackURL: callbackUrl,
     disableRedirect: options?.redirect === false,
+    errorCallbackURL: buildAuthCallbackUrl("/login?authError=line_oauth"),
     provider,
   });
 }

--- a/src/routes/api/auth/$.tsx
+++ b/src/routes/api/auth/$.tsx
@@ -1,11 +1,49 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { auth } from "@/lib/auth";
 
+const AUTH_ERROR_PATH = "/api/auth/error";
+const LINE_CALLBACK_PATH = "/api/auth/callback/line";
+
+const shouldHandleAuthErrorRedirect = (pathname: string) =>
+  pathname === LINE_CALLBACK_PATH || pathname === AUTH_ERROR_PATH;
+
+const createLoginErrorRedirect = (requestUrl: URL, error: string) => {
+  const loginUrl = new URL("/login", requestUrl.origin);
+  loginUrl.searchParams.set("authError", error);
+  return Response.redirect(loginUrl, 302);
+};
+
+const handleAuthRequest = async (request: Request) => {
+  const response = await auth.handler(request);
+  const requestUrl = new URL(request.url);
+
+  if (!shouldHandleAuthErrorRedirect(requestUrl.pathname)) {
+    return response;
+  }
+
+  const location = response.headers.get("location");
+  if (!location) {
+    return response;
+  }
+
+  const redirectUrl = new URL(location, requestUrl.origin);
+  if (redirectUrl.pathname !== AUTH_ERROR_PATH) {
+    return response;
+  }
+
+  const error = redirectUrl.searchParams.get("error");
+  if (!error) {
+    return response;
+  }
+
+  return createLoginErrorRedirect(requestUrl, error);
+};
+
 export const Route = createFileRoute("/api/auth/$")({
   server: {
     handlers: {
-      GET: ({ request }) => auth.handler(request),
-      POST: ({ request }) => auth.handler(request),
+      GET: ({ request }) => handleAuthRequest(request),
+      POST: ({ request }) => handleAuthRequest(request),
     },
   },
 });

--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -5,14 +5,34 @@ import React from "react";
 import { useSession } from "@/lib/auth/client";
 import { LineLoginButton } from "@/components/ui/LineLoginButton";
 
+const AUTH_ERROR_MESSAGES: Record<string, string> = {
+  invalid_code: "รหัสยืนยันจาก LINE ใช้ไม่ได้หรือหมดอายุ กรุณาเข้าสู่ระบบใหม่อีกครั้ง",
+  line_oauth: "เข้าสู่ระบบด้วย LINE ไม่สำเร็จ กรุณาเริ่มใหม่อีกครั้ง",
+  please_restart_the_process:
+    "ลิงก์เข้าสู่ระบบหมดอายุแล้ว กรุณากด LINE Login ใหม่จากหน้านี้",
+  state_mismatch:
+    "เซสชันเข้าสู่ระบบไม่ตรงกัน กรุณากด LINE Login ใหม่จากหน้านี้",
+};
+
 function LoginPage() {
   const { status } = useSession();
-  const search = useSearch({ strict: false }) as { callbackUrl?: string };
+  const search = useSearch({ strict: false }) as {
+    authError?: string;
+    callbackUrl?: string;
+    error?: string;
+  };
   // Only allow relative paths to prevent open redirect.
   // Reject absolute URLs (https://evil.com) and protocol-relative URLs (//evil.com).
   const rawCallback = typeof search.callbackUrl === "string" ? search.callbackUrl : "/";
   const callbackUrl =
     rawCallback.startsWith("/") && !rawCallback.startsWith("//") ? rawCallback : "/";
+  const authError = search.authError ?? search.error;
+  const authErrorMessage =
+    authError && AUTH_ERROR_MESSAGES[authError]
+      ? AUTH_ERROR_MESSAGES[authError]
+      : authError
+        ? "เข้าสู่ระบบไม่สำเร็จ กรุณากด LINE Login ใหม่อีกครั้ง"
+        : null;
 
   React.useEffect(() => {
     if (status === "authenticated") {
@@ -56,6 +76,15 @@ function LoginPage() {
           </div>
 
           <div className="space-y-6">
+            {authErrorMessage ? (
+              <div
+                role="alert"
+                className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm font-medium text-red-700 dark:border-red-800 dark:bg-red-950/30 dark:text-red-200"
+              >
+                {authErrorMessage}
+              </div>
+            ) : null}
+
             <LineLoginButton
               callbackUrl={callbackUrl}
               className="w-full transform py-3 text-base font-semibold transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg sm:py-4 sm:text-lg"


### PR DESCRIPTION
## Summary
- route Better Auth LINE callback errors back to `/login` instead of leaving users on `/api/auth/error`
- pass an explicit Better Auth `errorCallbackURL` for LINE social sign-in
- show Thai recovery messages for expired/mismatched OAuth state and invalid LINE codes

## Why
Better Auth requires OAuth `state` to exist in the verification store. If users reopen an old LINE SSO URL, use a consumed state, or return after the state expires, Better Auth correctly returns `please_restart_the_process`. This patch makes that failure recoverable by taking users back to the app login page so they start a fresh OAuth flow.

## Verification
- `bun run type-check`
- `bun run build`