### PR TITLE
fix(auth): remove LINE_CHANNEL_SECRET fallback for auth secret

### DIFF
--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -102,7 +102,7 @@ export const auth = betterAuth({
     },
   },
   plugins: [tanstackStartCookies()],
-  secret: env.AUTH_SECRET ?? env.LINE_CHANNEL_SECRET,
+  secret: env.AUTH_SECRET,
   trustedOrigins: getTrustedOrigins(),
   user: {
     fields: {


### PR DESCRIPTION
## Summary

- ลบ `LINE_CHANNEL_SECRET` fallback ออกจาก `betterAuth.secret`
- `AUTH_SECRET` ต้องถูก set โดยตรงเสมอ — ไม่ fallback ไปใช้ LINE webhook secret
- `LINE_CHANNEL_SECRET` มีหน้าที่ต่างกัน (ตรวจสอบ LINE Webhook signature) ไม่ควรนำมาใช้ sign cookies/sessions

## Why

การ fallback ไป `LINE_CHANNEL_SECRET` ทำให้:
- lifecycle ของ auth sessions ผูกกับ LINE webhook key
- ถ้า LINE rotate key → session ทุกอันหมดอายุโดยไม่ตั้งใจ
- error ไม่ชัดเจนเมื่อ `AUTH_SECRET` ไม่ได้ set

## What to check

ตั้งค่า `AUTH_SECRET` ใน GitHub Secrets และ `.env.local` ก่อน deploy