### PR TITLE
Fix LINE Login OAuth state handling

### DIFF
--- a/src/components/ui/LineLoginButton.tsx
+++ b/src/components/ui/LineLoginButton.tsx
@@ -26,45 +26,62 @@ interface LineLoginButtonProps {
 const X = 20; // px
 const iconSize = 24; // rendered SVG px
 
+const getCurrentCallbackUrl = () => {
+  if (typeof window === "undefined") {
+    return "/";
+  }
+
+  return `${window.location.pathname}${window.location.search}${window.location.hash}`;
+};
+
 export const LineLoginButton: React.FC<LineLoginButtonProps> = ({
   callbackUrl,
   className = "",
   children,
   disabled = false,
-}) => (
-  <button
-    id="btn-login-line"
-    type="button"
-    disabled={disabled}
-    onClick={() =>
-      !disabled &&
-      signIn("line", callbackUrl ? { callbackUrl } : undefined)
+}) => {
+  const handleClick = React.useCallback(() => {
+    if (!disabled) {
+      const signInOptions = {
+        callbackUrl: callbackUrl || getCurrentCallbackUrl(),
+      };
+      signIn("line", signInOptions).catch((error) => {
+        console.error("[LINE Login] Sign-in error:", error);
+      });
     }
-    style={
-      disabled
-        ? {
-            backgroundColor: "#FFFFFF",
-            border: "1px solid rgba(229,229,229,0.6)",
-          }
-        : {
-            backgroundColor: "#06C755",
-          }
-    }
-    className={[
-      // Layout
-      "group relative inline-flex items-stretch overflow-hidden",
-      // Shape
-      "rounded-[4px]",
-      // Cursor
-      disabled ? "cursor-not-allowed" : "cursor-pointer",
-      // Font — Helvetica Bold per spec
-      "font-['Helvetica_Neue',Helvetica,Arial,sans-serif]",
-      className,
-    ]
-      .filter(Boolean)
-      .join(" ")}
-  >
-    {/*
+  }, [disabled, callbackUrl]);
+
+  return (
+    <button
+      id="btn-login-line"
+      type="button"
+      disabled={disabled}
+      onClick={handleClick}
+      style={
+        disabled
+          ? {
+              backgroundColor: "#FFFFFF",
+              border: "1px solid rgba(229,229,229,0.6)",
+            }
+          : {
+              backgroundColor: "#06C755",
+            }
+      }
+      className={[
+        // Layout
+        "group relative inline-flex items-stretch overflow-hidden",
+        // Shape
+        "rounded-[4px]",
+        // Cursor
+        disabled ? "cursor-not-allowed" : "cursor-pointer",
+        // Font — Helvetica Bold per spec
+        "font-['Helvetica_Neue',Helvetica,Arial,sans-serif]",
+        className,
+      ]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      {/*
      ┌────────────────────────── Layer stacking (bottom → top) ─────────────────────────────┐
      │  1. Base color     → button background style above                                   │
      │  2. Hover overlay  → #000 10% on hover  /  #000 30% on press                        │
@@ -73,38 +90,38 @@ export const LineLoginButton: React.FC<LineLoginButtonProps> = ({
      └───────────────────────────────────────────────────────────────────────────────────────┘
     */}
 
-    {/* ── Layer 2: Hover / Press color overlay ── */}
-    {!disabled && (
-      <span
-        aria-hidden="true"
-        className="pointer-events-none absolute inset-0 rounded-[4px] bg-black opacity-0 transition-opacity duration-100 group-hover:opacity-[0.10] group-active:opacity-[0.30]"
-      />
-    )}
+      {/* ── Layer 2: Hover / Press color overlay ── */}
+      {!disabled && (
+        <span
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 rounded-[4px] bg-black opacity-0 transition-opacity duration-100 group-hover:opacity-[0.10] group-active:opacity-[0.30]"
+        />
+      )}
 
-    {/* ── Layer 4a: Icon section ──
+      {/* ── Layer 4a: Icon section ──
         Padding: X on left, X (min) on right, X/2 top & bottom
         → makes the icon region a proportional square                  */}
-    <span
-      aria-hidden="true"
-      className="relative z-10 flex shrink-0 items-center justify-center"
-      style={{
-        paddingTop: X / 2,
-        paddingBottom: X / 2,
-        paddingLeft: X,
-        paddingRight: X, // gap between icon and vertical line ≥ X
-      }}
-    >
-      <svg
-        id="icon-line-login-svg"
-        xmlns="http://www.w3.org/2000/svg"
-        width={iconSize}
-        height={iconSize}
-        viewBox="0 0 48 48"
+      <span
         aria-hidden="true"
+        className="relative z-10 flex shrink-0 items-center justify-center"
+        style={{
+          paddingTop: X / 2,
+          paddingBottom: X / 2,
+          paddingLeft: X,
+          paddingRight: X, // gap between icon and vertical line ≥ X
+        }}
       >
-        <path
-          fill={disabled ? "rgba(30,30,30,0.2)" : "#FFFFFF"}
-          d="M37.113,22.417c0-5.865-5.88-10.637-13.107-10.637
+        <svg
+          id="icon-line-login-svg"
+          xmlns="http://www.w3.org/2000/svg"
+          width={iconSize}
+          height={iconSize}
+          viewBox="0 0 48 48"
+          aria-hidden="true"
+        >
+          <path
+            fill={disabled ? "rgba(30,30,30,0.2)" : "#FFFFFF"}
+            d="M37.113,22.417c0-5.865-5.88-10.637-13.107-10.637
             s-13.108,4.772-13.108,10.637c0,5.258,4.663,9.662,10.962,10.495
             c0.427,0.092,1.008,0.282,1.155,0.646c0.132,0.331,0.086,0.85,0.042,1.185
             c0,0-0.153,0.925-0.187,1.122c-0.057,0.331-0.263,1.296,1.135,0.707
@@ -129,42 +146,41 @@ export const LineLoginButton: React.FC<LineLoginButtonProps> = ({
             c0-0.001,0-0.001,0-0.001c0,0,0-0.001,0-0.001v-2.601
             c0-0.001,0-0.001,0-0.002c0-0.379,0.308-0.687,0.687-0.687h2.604
             c0.379,0,0.688,0.308,0.688,0.687s-0.308,0.687-0.688,0.687h-1.917v1.23H32.052z"
-        />
-      </svg>
-    </span>
+          />
+        </svg>
+      </span>
 
-    {/* ── Layer 3: Vertical divider ──
+      {/* ── Layer 3: Vertical divider ──
         Non-disabled: #000000 8%   |   Disabled: #E5E5E5 60%           */}
-    <span
-      aria-hidden="true"
-      className="relative z-10 shrink-0 self-stretch"
-      style={{
-        width: "1px",
-        background: disabled
-          ? "rgba(229,229,229,0.6)"
-          : "rgba(0,0,0,0.08)",
-      }}
-    />
+      <span
+        aria-hidden="true"
+        className="relative z-10 shrink-0 self-stretch"
+        style={{
+          width: "1px",
+          background: disabled ? "rgba(229,229,229,0.6)" : "rgba(0,0,0,0.08)",
+        }}
+      />
 
-    {/* ── Layer 4b: Text section ──
+      {/* ── Layer 4b: Text section ──
         Font: Helvetica Bold, centered
         Padding: X (min) on left/right, X/2 top/bottom                 */}
-    <span
-      id="text-login-line"
-      className="relative z-10 flex flex-1 items-center justify-center"
-      style={{
-        paddingTop: X / 2,
-        paddingBottom: X / 2,
-        paddingLeft: X,
-        paddingRight: X,
-        fontSize: 14,
-        fontWeight: "bold",
-        letterSpacing: "0.01em",
-        color: disabled ? "rgba(30,30,30,0.2)" : "#FFFFFF",
-        whiteSpace: "nowrap",
-      }}
-    >
-      {children ?? "Log in with LINE"}
-    </span>
-  </button>
-);
+      <span
+        id="text-login-line"
+        className="relative z-10 flex flex-1 items-center justify-center"
+        style={{
+          paddingTop: X / 2,
+          paddingBottom: X / 2,
+          paddingLeft: X,
+          paddingRight: X,
+          fontSize: 14,
+          fontWeight: "bold",
+          letterSpacing: "0.01em",
+          color: disabled ? "rgba(30,30,30,0.2)" : "#FFFFFF",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {children ?? "Log in with LINE"}
+      </span>
+    </button>
+  );
+};

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -13,10 +13,7 @@ export const env = createEnv({
     APP_ENV: z
       .enum(["development", "test", "production"])
       .default("development"),
-    AUTH_SECRET:
-      process.env.APP_ENV === "production"
-        ? z.string().min(1)
-        : z.string().min(1).optional(),
+    AUTH_SECRET: z.string().min(32, "AUTH_SECRET must be at least 32 characters"),
     APP_URL: z.string().url(),
     LINE_CLIENT_ID: z.string(),
     LINE_CLIENT_SECRET: z.string(),
@@ -46,7 +43,10 @@ export const env = createEnv({
   runtimeEnv: {
     DATABASE_URL: process.env.DATABASE_URL,
     APP_ENV: process.env.APP_ENV,
-    AUTH_SECRET: process.env.AUTH_SECRET,
+    AUTH_SECRET: process.env.AUTH_SECRET ||
+      (process.env.APP_ENV === "development"
+        ? "development-secret-key-min-32-chars-long-please-change-in-production"
+        : undefined),
     APP_URL: process.env.APP_URL ?? process.env.FRONTEND_URL,
     LINE_CLIENT_ID: process.env.LINE_CLIENT_ID,
     LINE_CLIENT_SECRET: process.env.LINE_CLIENT_SECRET,

--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -32,21 +32,39 @@ const getAuthBaseUrl = () => {
   return env.APP_URL;
 };
 
-const getTrustedOrigins = () =>
-  Array.from(
-    new Set(
-      [
-        env.APP_URL,
-        env.FRONTEND_URL,
-        env.APP_DOMAIN,
-        ...(env.APP_ENV === "development"
-          ? [getLocalDevOrigin(), getLoopbackDevOrigin()]
-          : []),
-      ].map((url) => {
-        return new URL(url).origin;
-      }),
-    ),
-  );
+const getTrustedOrigins = () => {
+  const origins = [
+    env.APP_URL,
+    env.FRONTEND_URL,
+    env.APP_DOMAIN,
+    ...(env.APP_ENV === "development"
+      ? [getLocalDevOrigin(), getLoopbackDevOrigin()]
+      : []),
+  ];
+
+  // Support comma-separated URLs in environment variables
+  const expandedOrigins = origins.flatMap((url) => {
+    if (!url) return [];
+    return url
+      .split(",")
+      .map((u) => {
+        const trimmed = u.trim();
+        try {
+          const origin = new URL(trimmed).origin;
+          return origin;
+        } catch {
+          console.warn(`[Auth] Invalid URL in trusted origins: "${trimmed}"`);
+          return null;
+        }
+      })
+      .filter((origin): origin is string => origin !== null);
+  });
+
+  const uniqueOrigins = Array.from(new Set(expandedOrigins));
+  console.log(`[Auth] Trusted origins:`, uniqueOrigins);
+
+  return uniqueOrigins;
+};
 
 const createSyntheticLineEmail = (lineUserId: string) => {
   const normalizedId =
@@ -59,7 +77,9 @@ const createSyntheticLineEmail = (lineUserId: string) => {
 };
 
 const toIsoString = (value: Date | string) => {
-  return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+  return value instanceof Date
+    ? value.toISOString()
+    : new Date(value).toISOString();
 };
 
 const syncLineApprovalRequest = async (account: {
@@ -74,21 +94,27 @@ const syncLineApprovalRequest = async (account: {
 
   const lineUserId = account.accountId;
   if (!lineUserId) {
+    console.warn("[LINE Profile Sync] Missing LINE user ID");
     return;
   }
 
-  const user = await db.user.findUnique({
-    where: { id: account.userId },
-    select: { name: true, image: true },
-  });
+  try {
+    const user = await db.user.findUnique({
+      where: { id: account.userId },
+      select: { name: true, image: true },
+    });
 
-  await syncLineProfileToDatabase({
-    accessToken: account.accessToken,
-    fallbackDisplayName: user?.name,
-    fallbackPictureUrl: user?.image,
-    lineUserId,
-    userId: account.userId,
-  });
+    await syncLineProfileToDatabase({
+      accessToken: account.accessToken,
+      fallbackDisplayName: user?.name,
+      fallbackPictureUrl: user?.image,
+      lineUserId,
+      userId: account.userId,
+    });
+  } catch (error) {
+    console.error("[LINE Profile Sync] Database sync failed:", error);
+    throw error;
+  }
 };
 
 export const auth = betterAuth({
@@ -122,10 +148,10 @@ export const auth = betterAuth({
     },
   },
   account: {
-    // LINE Login can complete in a different browser context than the one that
-    // started the flow, so the signed state cookie may not be returned on the
-    // callback. Keep Better Auth's database-backed state + PKCE checks, but do
-    // not require the extra cookie binding.
+    // LINE Login can complete in a different browser context (e.g., LINE app)
+    // than the one that started the flow, so the signed state cookie may not
+    // be returned on the callback. Keep Better Auth's database-backed state
+    // + PKCE checks for security, but do not require the extra cookie binding.
     skipStateCookieCheck: true,
     fields: {
       accountId: "providerAccountId",
@@ -136,6 +162,7 @@ export const auth = betterAuth({
     },
   },
   verification: {
+    modelName: "verificationToken",
     fields: {
       expiresAt: "expires",
       value: "token",
@@ -146,6 +173,7 @@ export const auth = betterAuth({
       clientId: env.LINE_CLIENT_ID,
       clientSecret: env.LINE_CLIENT_SECRET,
       overrideUserInfoOnSignIn: true,
+      enableStateParam: true,
       mapProfileToUser(profile) {
         const lineProfile = profile as {
           displayName?: string;
@@ -157,6 +185,10 @@ export const auth = betterAuth({
           userId?: string;
         };
         const lineUserId = lineProfile.sub ?? lineProfile.userId ?? "";
+
+        if (!lineUserId) {
+          throw new Error("Invalid LINE profile: missing user ID");
+        }
 
         return {
           email:
@@ -183,8 +215,9 @@ export const auth = betterAuth({
         async after(account) {
           try {
             await syncLineApprovalRequest(account);
-          } catch {
+          } catch (error) {
             // ไม่ throw error เพื่อไม่ให้กระทบการ login
+            console.error("[LINE Profile Sync Error]", error);
           }
         },
       },
@@ -200,8 +233,9 @@ export const auth = betterAuth({
         async after(account) {
           try {
             await syncLineApprovalRequest(account);
-          } catch {
+          } catch (error) {
             // ไม่ throw error เพื่อไม่ให้กระทบการ login
+            console.error("[LINE Profile Sync Error]", error);
           }
         },
       },

--- a/src/routes/api/auth/$.tsx
+++ b/src/routes/api/auth/$.tsx
@@ -15,29 +15,46 @@ const createLoginErrorRedirect = (error: string) => {
 };
 
 const handleAuthRequest = async (request: Request) => {
-  const response = await auth.handler(request);
-  const requestUrl = new URL(request.url);
+  try {
+    console.log("[Auth Handler] Processing request:", {
+      method: request.method,
+      url: request.url,
+    });
 
-  if (!shouldHandleAuthErrorRedirect(requestUrl.pathname)) {
-    return response;
+    const response = await auth.handler(request);
+    const requestUrl = new URL(request.url);
+
+    if (!shouldHandleAuthErrorRedirect(requestUrl.pathname)) {
+      return response;
+    }
+
+    const location = response.headers.get("location");
+    if (!location) {
+      return response;
+    }
+
+    const redirectUrl = new URL(location, requestUrl.origin);
+    if (redirectUrl.pathname !== AUTH_ERROR_PATH) {
+      return response;
+    }
+
+    const error = redirectUrl.searchParams.get("error");
+    if (!error) {
+      return response;
+    }
+
+    return createLoginErrorRedirect(error);
+  } catch (error) {
+    console.error("[Auth Handler] Error processing auth request:", error);
+
+    // Return a more specific error for debugging
+    const errorMessage = error instanceof Error ? error.message : "Unknown error";
+    const loginUrl = new URL("/login", new URL(env.APP_URL).origin);
+    loginUrl.searchParams.set("authError", "line_oauth");
+    loginUrl.searchParams.set("error", errorMessage);
+
+    return Response.redirect(loginUrl, 302);
   }
-
-  const location = response.headers.get("location");
-  if (!location) {
-    return response;
-  }
-
-  const redirectUrl = new URL(location, requestUrl.origin);
-  if (redirectUrl.pathname !== AUTH_ERROR_PATH) {
-    return response;
-  }
-
-  const error = redirectUrl.searchParams.get("error");
-  if (!error) {
-    return response;
-  }
-
-  return createLoginErrorRedirect(error);
 };
 
 export const Route = createFileRoute("/api/auth/$")({

--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -54,9 +54,9 @@ function LoginPage() {
   }
 
   return (
-    <main className="relative flex h-screen w-full items-center justify-center overflow-hidden">
-      {/* Gradient Background */}
-      <div className="pointer-events-none absolute inset-0">
+    <main className="relative flex h-screen w-full items-center justify-center overflow-hidden bg-gradient-to-br from-gray-50 to-gray-100">
+      {/* Gradient Background - ensure pointer-events-none */}
+      <div className="pointer-events-none absolute inset-0 -z-10">
         <div className="absolute -right-40 -top-40 h-80 w-80 rounded-full bg-gradient-to-br from-purple-400/20 to-pink-600/20 blur-3xl"></div>
         <div className="absolute -bottom-40 -left-40 h-80 w-80 rounded-full bg-gradient-to-tr from-indigo-400/20 to-purple-600/20 blur-3xl"></div>
       </div>


### PR DESCRIPTION
## Summary

Fix LINE Login startup failures and make the OAuth flow more resilient.

## Changes

- Map Better Auth verification storage to the existing Prisma `verificationToken` model so `/api/auth/sign-in/social` can create OAuth state without returning 500.
- Add a fallback callback URL in `LineLoginButton` using the current browser path when no `callbackUrl` prop is provided.
- Improve LINE auth handling by keeping state enabled, preserving LINE app callback compatibility, and logging auth/profile sync failures more clearly.
- Tighten auth env validation with a development fallback secret.
- Keep login error redirects user-facing through `/login`.

## Verification

- `bun run type-check`
- Manually tested `POST /api/auth/sign-in/social` locally and confirmed it returns `200` with a LINE authorization URL instead of `500`.

## Notes

- A temporary OAuth verification row created during manual testing was removed.
- Port `4325` was freed after testing.
