### PR TITLE
fix(auth): handle duplicate session token on LINE OAuth callback retry

### DIFF
--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -254,6 +254,20 @@ export const auth = betterAuth({
     },
   },
   databaseHooks: {
+    session: {
+      create: {
+        async before(session) {
+          // Handle duplicate session token from OAuth callback retries
+          // (e.g. Cloudflare Tunnel retrying the LINE callback request)
+          try {
+            await db.session.deleteMany({ where: { token: session.token } });
+          } catch {
+            // ignore — if delete fails, let create proceed and surface the real error
+          }
+          return { data: session };
+        },
+      },
+    },
     account: {
       create: {
         async after(account) {


### PR DESCRIPTION
## Summary

- Found root cause of `line_oauth` error: `PrismaClientKnownRequestError P2002` — unique constraint on `sessions_session_token_key` when `prisma.session.create()` is called with a token that already exists
- Cause: Cloudflare Tunnel / browser retries the LINE OAuth callback, better-auth generates the same deterministic session token, second attempt hits the unique constraint and returns 500
- Fix: add `databaseHooks.session.create.before` to delete any existing session with the same token before inserting, turning the retry into a clean upsert

## Test plan

- [ ] Login with LINE on `bun-line.midseelee.com` completes without `?authError=line_oauth`
- [ ] Repeated login attempts (simulate retry) succeed without 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)