### PR TITLE
fix(db): intercept session P2002 at Prisma level instead of databaseHooks

### DIFF
--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -254,20 +254,6 @@ export const auth = betterAuth({
     },
   },
   databaseHooks: {
-    session: {
-      create: {
-        async before(session) {
-          // Handle duplicate session token from OAuth callback retries
-          // (e.g. Cloudflare Tunnel retrying the LINE callback request)
-          try {
-            await db.session.deleteMany({ where: { token: session.token } });
-          } catch {
-            // ignore — if delete fails, let create proceed and surface the real error
-          }
-          return { data: session };
-        },
-      },
-    },
     account: {
       create: {
         async after(account) {

--- a/src/lib/database/db.ts
+++ b/src/lib/database/db.ts
@@ -1,17 +1,46 @@
-import { PrismaClient } from "@prisma/client";
+import { PrismaClient, Prisma } from "@prisma/client";
 
-// Add error handling for Prisma connection
 const globalForPrisma = globalThis as unknown as {
-  prisma: PrismaClient | undefined;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  prisma: any | undefined;
 };
 
-const createClient = () =>
-  new PrismaClient({
+const createClient = () => {
+  const base = new PrismaClient({
     log:
       process.env.NODE_ENV === "development"
         ? ["query", "error", "warn"]
         : ["error"],
   });
+
+  // Intercept session.create to handle duplicate token errors (P2002).
+  // better-auth can generate the same session token when the LINE OAuth
+  // callback is retried (e.g. Cloudflare Tunnel retry). The unique index
+  // on `sessions.token` rejects the second insert — delete the stale
+  // record and retry so the caller gets a valid session instead of a 500.
+  return base.$extends({
+    query: {
+      session: {
+        async create({ args, query }) {
+          try {
+            return await query(args);
+          } catch (e: unknown) {
+            const token = (args.data as Record<string, unknown>)?.token;
+            if (
+              e instanceof Prisma.PrismaClientKnownRequestError &&
+              e.code === "P2002" &&
+              typeof token === "string"
+            ) {
+              await base.session.deleteMany({ where: { token } }).catch(() => {});
+              return await query(args);
+            }
+            throw e;
+          }
+        },
+      },
+    },
+  });
+};
 
 /**
  * ตรวจสอบว่า cached instance มี model ครบหรือไม่
@@ -20,7 +49,6 @@ const createClient = () =>
  */
 const isCacheStale = (client: PrismaClient): boolean => {
   try {
-    // ตรวจสอบ model ล่าสุดที่เพิ่มเข้ามา — ถ้าไม่มีแสดงว่า client เก่า
     return !("lineApprovalRequest" in client) || !("subscription" in client);
   } catch {
     return true;


### PR DESCRIPTION
## Summary

- The previous fix used `databaseHooks.session.create.before` which better-auth v1.6.1 does not route session operations through — the hook was silently ignored
- Replace with a Prisma `$extends` query extension on `session.create` that catches P2002 (duplicate token), deletes the stale record, and retries

## Root cause

better-auth generates the same deterministic session token when the LINE OAuth callback is retried (Cloudflare Tunnel retry). The unique index on `sessions.token` rejects the second insert with P2002 → 500 → `?authError=line_oauth`.

## Test plan

- [ ] Login with LINE on `bun-line.midseelee.com` completes without `?authError=line_oauth`
- [ ] No P2002 errors in Docker logs after login

🤖 Generated with [Claude Code](https://claude.com/claude-code)