### PR TITLE
fix(line): fix webhook signature, account checks, and remove invalid 401 responses

### DIFF
--- a/src/features/line/commands/handleLocation.ts
+++ b/src/features/line/commands/handleLocation.ts
@@ -1,9 +1,13 @@
 import { airVisualService } from "@/features/air-quality/services/airvisual.server";
 import { sendMessage } from "../../../lib/utils/line-utils";
 import { flexMessage, replyNotFound } from "@/lib/utils/line-message-utils";
+import { getLineUserAccount } from "../utils/getLineUserAccount";
 
 export const handleLocation = async (req: any, event: any) => {
   try {
+    const account = await getLineUserAccount(event);
+    if (!account) return;
+
     const location: any = await airVisualService.getNearestCity(
       event.message.latitude,
       event.message.longitude,

--- a/src/features/line/commands/handleLogin.ts
+++ b/src/features/line/commands/handleLogin.ts
@@ -1,8 +1,8 @@
-import { db } from "../../../lib/database/db";
 import { bubbleTemplate } from "@/lib/validation/line";
 import { sendMessage } from "../../../lib/utils/line-utils";
 import { flexMessage } from "@/lib/utils/line-message-utils";
 import { handleText } from "./handleText";
+import { getLineUserAccount } from "../utils/getLineUserAccount";
 
 export const handleLogin = async (req: any, message: string) => {
   const prefix = message[0] || "";
@@ -11,10 +11,8 @@ export const handleLogin = async (req: any, message: string) => {
     return;
   }
 
-  const userId = req.body?.events?.[0]?.source?.userId;
-  const userPermission: any = await db.account.findFirst({
-    where: { accountId: userId },
-  });
+  const event = req.body?.events?.[0];
+  const userPermission = await getLineUserAccount(event);
 
   if (!userPermission) {
     const payload = bubbleTemplate.signIn();

--- a/src/features/line/commands/handlePostback.ts
+++ b/src/features/line/commands/handlePostback.ts
@@ -1,5 +1,4 @@
 import { attendanceService } from "@/features/attendance/services/attendance.server";
-import { db } from "../../../lib/database/db";
 import { bubbleTemplate } from "@/lib/validation/line";
 import { sendMessage } from "../../../lib/utils/line-utils";
 import { flexMessage } from "@/lib/utils/line-message-utils";
@@ -10,17 +9,15 @@ import { handleWorkStatus } from "./handleWorkStatus";
 import { handleCheckInMenu } from "./handleCheckInMenu";
 import { handleMonthlyReport } from "./handleMonthlyReport";
 import { handleReportMenu } from "./handleReportMenu";
+import { getLineUserAccount } from "../utils/getLineUserAccount";
 
 export const handlePostback = async (req: any, event: any) => {
-  const userId = req.body.events[0].source.userId;
-  const data = event.postback.data;
-  const userPermission: any = await db.account.findFirst({
-    where: { accountId: userId },
-  });
+  const userPermission = await getLineUserAccount(event);
   if (!userPermission) {
     const payload = bubbleTemplate.signIn();
     return sendMessage(req, flexMessage(payload));
   }
+  const data = event.postback.data;
   const params = new URLSearchParams(data);
   const action = params.get("action");
   switch (action) {

--- a/src/features/line/commands/handleSticker.ts
+++ b/src/features/line/commands/handleSticker.ts
@@ -1,5 +1,6 @@
 import { sendMessage } from "@/lib/utils/line-utils";
 import { getConsolationMessage } from "@/lib/utils/ai-message-generator";
+import { getLineUserAccount } from "../utils/getLineUserAccount";
 
 /**
  * Handle sticker messages from LINE users
@@ -31,9 +32,12 @@ function isSadSticker(keywords: string[]): boolean {
  */
 export const handleSticker = async (
   req: any,
-  event: StickerEvent,
+  event: StickerEvent & { source?: { userId?: string } },
 ): Promise<void> => {
   try {
+    const account = await getLineUserAccount(event);
+    if (!account) return;
+
     if (!event.message?.keywords || !Array.isArray(event.message.keywords)) {
       return;
     }

--- a/src/features/line/services/line.server.ts
+++ b/src/features/line/services/line.server.ts
@@ -55,7 +55,7 @@ const handleEvent = async (
             await handleLocation(req, event);
             break;
           default:
-            res.status(401).send("Invalid token");
+            // ประเภทข้อความที่ไม่รองรับ — ไม่ต้องทำอะไร LINE ต้องการแค่ 200 OK
             break;
         }
         break;
@@ -63,7 +63,8 @@ const handleEvent = async (
         await handlePostback(req, event);
         break;
       default:
-        res.status(401).send("Invalid token");
+        // event type ที่ไม่รองรับ — ไม่ต้องทำอะไร LINE ต้องการแค่ 200 OK
+        break;
     }
   }
 };

--- a/src/features/line/utils/getLineUserAccount.ts
+++ b/src/features/line/utils/getLineUserAccount.ts
@@ -1,0 +1,13 @@
+import { db } from "@/lib/database/db";
+
+/**
+ * ดึง LINE userId จาก event และ account ที่ผูกไว้ในระบบ
+ * คืน null ถ้าไม่มี userId หรือยังไม่ได้ผูก account
+ */
+export const getLineUserAccount = async (event: any) => {
+  const userId: string | undefined = event?.source?.userId;
+  if (!userId) return null;
+
+  const account = await db.account.findFirst({ where: { accountId: userId } });
+  return account ?? null;
+};

--- a/src/routes/api/line.tsx
+++ b/src/routes/api/line.tsx
@@ -6,13 +6,13 @@ import crypto from "node:crypto";
 
 export async function POST(req: Request) {
   try {
-    const body = await req.json();
-    const data = JSON.stringify(body);
+    const rawBody = await req.text();
+    const body = JSON.parse(rawBody);
 
     const secret = env.LINE_CHANNEL_SECRET;
     const signature = crypto
       .createHmac("SHA256", secret as string)
-      .update(data as string)
+      .update(rawBody)
       .digest("base64")
       .toString();
 


### PR DESCRIPTION
## Summary
- Fix LINE webhook signature mismatch by computing HMAC over raw request body instead of re-serialized JSON
- Extract `getLineUserAccount` utility to eliminate duplicated `db.account.findFirst` pattern across `handlePostback`, `handleLogin`, `handleSticker`, `handleLocation`
- Fix `handlePostback` using `event.source.userId` instead of always reading `events[0]`
- Add account check to `handleSticker` and `handleLocation`
- Remove `res.status(401)` from default event type handlers — LINE webhook only needs HTTP 200 OK; user-facing errors must go through the Reply API

## Test plan
- [ ] Send a message from an approved LINE user — webhook should process normally
- [ ] Send a sticker/location from a user without a linked account — should silently ignore
- [ ] Send a postback from an approved user — should use correct event userId
- [ ] Verify signature mismatch no longer occurs for valid LINE webhook requests