### PR TITLE
fix(auth): handle LINE account unique constraint with custom adapter

### DIFF
--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -1,5 +1,4 @@
 import { betterAuth } from "better-auth";
-import { prismaAdapter } from "better-auth/adapters/prisma";
 import { tanstackStartCookies } from "better-auth/tanstack-start";
 import { getRequest } from "@tanstack/react-start/server";
 import { env } from "@/env.mjs";
@@ -7,6 +6,7 @@ import { db } from "../database/db";
 import type { AppSession } from "./session-context";
 import { syncLineProfileToDatabase } from "./line-profile-sync";
 import { isAllowedHost } from "@/lib/security/url-validator";
+import { createCustomPrismaAdapter } from "./prisma-adapter";
 
 const LINE_FALLBACK_EMAIL_DOMAIN = "line.local";
 const DEFAULT_DEV_PORT = "4325";
@@ -194,7 +194,7 @@ validateProductionDomains();
 
 export const auth = betterAuth({
   baseURL: getAuthBaseUrl(),
-  database: prismaAdapter(db, {
+  database: createCustomPrismaAdapter(db, {
     provider: "mongodb",
   }),
   advanced: {
@@ -268,55 +268,6 @@ export const auth = betterAuth({
   databaseHooks: {
     account: {
       create: {
-        async before(account) {
-          // Check if account already exists to prevent unique constraint violations
-          const existing = await db.account.findUnique({
-            where: {
-              providerId_accountId: {
-                providerId: account.providerId,
-                accountId: account.accountId,
-              },
-            },
-            select: {
-              id: true,
-              userId: true,
-            },
-          });
-
-          if (existing) {
-            console.log(
-              `[Auth] Account already exists for ${account.providerId}:${account.accountId} (userId: ${existing.userId})`,
-            );
-
-            // Update existing account with new tokens/data
-            await db.account.update({
-              where: {
-                providerId_accountId: {
-                  providerId: account.providerId,
-                  accountId: account.accountId,
-                },
-              },
-              data: {
-                accessToken: account.accessToken,
-                refreshToken: account.refreshToken,
-                idToken: account.idToken,
-                accessTokenExpiresAt: account.accessTokenExpiresAt,
-                refreshTokenExpiresAt: account.refreshTokenExpiresAt,
-                scope: account.scope,
-                updatedAt: new Date(),
-              },
-            });
-
-            console.log(
-              `[Auth] Updated existing account tokens for ${account.providerId}:${account.accountId}`,
-            );
-
-            // Return null to prevent creation - we've updated the existing account
-            return null;
-          }
-
-          return account;
-        },
         async after(account) {
           try {
             await syncLineApprovalRequest(account);

--- a/src/lib/auth/prisma-adapter.ts
+++ b/src/lib/auth/prisma-adapter.ts
@@ -1,0 +1,88 @@
+import { prismaAdapter } from "better-auth/adapters/prisma";
+import type { PrismaClient } from "@prisma/client";
+
+/**
+ * Custom Prisma adapter that handles account linking for LINE provider
+ * by using upsert instead of create to avoid unique constraint violations
+ */
+export function createCustomPrismaAdapter(
+  prisma: PrismaClient,
+  options?: { provider?: "mongodb" },
+) {
+  const baseAdapter = prismaAdapter(prisma, {
+    provider: options?.provider || "mongodb",
+  });
+
+  return {
+    ...baseAdapter,
+    create: async (data: any) => {
+      // Handle LINE account creation with upsert
+      if (
+        data.model === "account" &&
+        data.data.providerId === "line" &&
+        "accountId" in data.data
+      ) {
+        console.log(
+          `[Custom Adapter] Using upsert for LINE account: ${data.data.accountId}`,
+        );
+
+        try {
+          // Try to create first (normal flow)
+          return await (baseAdapter as any).create(data);
+        } catch (error: any) {
+          // If unique constraint error, update instead
+          if (
+            error?.code === "P2002" ||
+            error?.message?.includes("Unique constraint") ||
+            error?.message?.includes("accounts_provider_provider_account_id_key")
+          ) {
+            console.log(
+              `[Custom Adapter] Account exists, updating LINE account: ${data.data.accountId}`,
+            );
+
+            // Update existing account
+            const updated = await prisma.account.update({
+              where: {
+                providerId_accountId: {
+                  providerId: data.data.providerId as string,
+                  accountId: data.data.accountId as string,
+                },
+              },
+              data: {
+                accessToken:
+                  "accessToken" in data.data ? data.data.accessToken : undefined,
+                refreshToken:
+                  "refreshToken" in data.data
+                    ? data.data.refreshToken
+                    : undefined,
+                idToken: "idToken" in data.data ? data.data.idToken : undefined,
+                accessTokenExpiresAt:
+                  "accessTokenExpiresAt" in data.data
+                    ? data.data.accessTokenExpiresAt
+                    : undefined,
+                refreshTokenExpiresAt:
+                  "refreshTokenExpiresAt" in data.data
+                    ? data.data.refreshTokenExpiresAt
+                    : undefined,
+                scope: "scope" in data.data ? data.data.scope : undefined,
+                updatedAt: new Date(),
+              },
+            });
+
+            console.log(
+              `[Custom Adapter] ✅ Updated LINE account: ${data.data.accountId}`,
+            );
+
+            return updated;
+          }
+
+          // Re-throw if not a unique constraint error
+          throw error;
+        }
+      }
+
+      // Default behavior for other models
+      return await (baseAdapter as any).create(data);
+    },
+  };
+}


### PR DESCRIPTION
## Problem
Previous attempt using before hooks to prevent unique constraint violations
didn't work. Users still get errors when signing in with LINE:

```
Unique constraint failed on the constraint: accounts_provider_provider_account_id_key
```

## Root Cause
The before hook returning `null` doesn't properly prevent Better Auth from
attempting to create the account. We need to handle this at the database
operation level.

## Solution
**Custom Prisma Adapter** that wraps the default adapter and catches unique
constraint violations for LINE accounts:

1. **Try create first** - Normal flow for new accounts
2. **Catch P2002 error** - Detect unique constraint violations  
3. **Update existing** - Update tokens on existing account instead of failing
4. **Return updated account** - Continue sign-in flow normally

## Technical Details

### New: `src/lib/auth/prisma-adapter.ts`
- Wraps `prismaAdapter` with custom error handling
- Intercepts `create` operations for LINE provider accounts
- Uses try-catch to catch Prisma P2002 errors
- Automatically updates existing accounts with fresh tokens:
  - accessToken, refreshToken, idToken
  - accessTokenExpiresAt, refreshTokenExpiresAt
  - scope, updatedAt

### Updated: `src/lib/auth/auth.ts`
- Import and use `createCustomPrismaAdapter` instead of `prismaAdapter`
- Removed before hook that wasn't working

## Advantages Over Before Hook
✅ Handles error at database level (more reliable)
✅ No need to return null (which doesn't work properly)
✅ Automatic fallback to update on error
✅ Cleaner separation of concerns

## Testing
- Users can sign in with LINE multiple times
- Existing accounts get fresh tokens automatically
- No more unique constraint errors

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>