### PR TITLE
fix(auth): handle LINE Login and Messaging API unique constraints

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -372,18 +372,19 @@ enum ApprovalStatus {
 }
 
 model LineApprovalRequest {
-  id            String         @id @default(auto()) @map("_id") @db.ObjectId
-  lineUserId    String         @unique @map("line_user_id") // LINE user ID
-  displayName   String?        @map("display_name") // ชื่อที่แสดงใน LINE
-  pictureUrl    String?        @map("picture_url") // รูปโปรไฟล์ LINE
-  statusMessage String?        @map("status_message") // สถานะ LINE
-  reason        String?        @map("reason") // เหตุผลที่ขอใช้งาน
-  rejectReason  String?        @map("reject_reason") // เหตุผลที่ปฏิเสธ (ถ้ามี)
-  status        ApprovalStatus @default(PENDING) @map("status")
-  approvedBy    String?        @map("approved_by") // admin user id ที่อนุมัติ
-  approvedAt    DateTime?      @map("approved_at") // วันที่อนุมัติ
-  expiresAt     DateTime?      @map("expires_at") // null = ไม่หมดอายุ
-  notifiedAt    DateTime?      @map("notified_at") // วันที่แจ้งเตือน LINE ผู้ใช้
+  id              String         @id @default(auto()) @map("_id") @db.ObjectId
+  lineUserId      String         @unique @map("line_user_id") // LINE Messaging API (Bot) user ID
+  loginLineUserId String?        @unique @map("login_line_user_id") // LINE Login (web app) user ID — อาจต่างจาก Bot channel
+  displayName     String?        @map("display_name") // ชื่อที่แสดงใน LINE
+  pictureUrl      String?        @map("picture_url") // รูปโปรไฟล์ LINE
+  statusMessage   String?        @map("status_message") // สถานะ LINE
+  reason          String?        @map("reason") // เหตุผลที่ขอใช้งาน
+  rejectReason    String?        @map("reject_reason") // เหตุผลที่ปฏิเสธ (ถ้ามี)
+  status          ApprovalStatus @default(PENDING) @map("status")
+  approvedBy      String?        @map("approved_by") // admin user id ที่อนุมัติ
+  approvedAt      DateTime?      @map("approved_at") // วันที่อนุมัติ
+  expiresAt       DateTime?      @map("expires_at") // null = ไม่หมดอายุ
+  notifiedAt      DateTime?      @map("notified_at") // วันที่แจ้งเตือน LINE ผู้ใช้
 
   // Feature permissions
   canRequestAttendanceReport Boolean @default(false) @map("can_request_attendance_report") // ขอรายงานเข้างานได้

--- a/src/features/attendance/services/attendance.server.ts
+++ b/src/features/attendance/services/attendance.server.ts
@@ -86,6 +86,33 @@ async function isWorkingDay(date: Date): Promise<boolean> {
  * @param todayString วันที่รูปแบบ YYYY-MM-DD (Bangkok)
  * @returns string[] LINE userId
  */
+/**
+ * ดึง Messaging API user ID สำหรับ push notification
+ * account.accountId = LINE Login channel ID (อาจต่างจาก Messaging API channel ID)
+ * ต้อง push ด้วย lineApprovalRequest.lineUserId (Messaging API ID เสมอ)
+ */
+async function resolveMessagingApiUserId(
+  loginChannelId: string,
+): Promise<{ messagingUserId: string; canReceiveReminders: boolean } | null> {
+  const approval = await db.lineApprovalRequest.findFirst({
+    where: {
+      OR: [
+        { lineUserId: loginChannelId },
+        { loginLineUserId: loginChannelId },
+      ],
+    },
+    select: {
+      lineUserId: true,
+      canReceiveReminders: true,
+    },
+  });
+  if (!approval) return null;
+  return {
+    messagingUserId: approval.lineUserId,
+    canReceiveReminders: approval.canReceiveReminders ?? false,
+  };
+}
+
 async function getActiveLineUserIdsForCheckinReminder(
   todayString: string,
 ): Promise<string[]> {
@@ -109,33 +136,18 @@ async function getActiveLineUserIdsForCheckinReminder(
       },
     });
 
-    // Check if user has notifications enabled (default is true if no settings)
     const notificationsEnabled = user?.settings?.enableCheckInReminders ?? true;
+    const loginChannelId = user?.accounts[0]?.accountId;
 
-    // Check LINE permissions
-    const lineUserId = user?.accounts[0]?.accountId;
-    let hasReminderPermission = false;
-    if (lineUserId) {
-      const approval = await db.lineApprovalRequest.findUnique({
-        where: { lineUserId },
-        select: { canReceiveReminders: true },
-      });
-      hasReminderPermission = approval?.canReceiveReminders ?? false;
-    }
-
-    if (
-      user &&
-      user.accounts.length > 0 &&
-      user.leaves.length === 0 &&
-      notificationsEnabled &&
-      hasReminderPermission
-    ) {
-      return [user.accounts[0]?.accountId].filter(
-        (id): id is string => typeof id === "string",
-      );
-    } else {
+    if (!loginChannelId || !user || user.leaves.length > 0 || !notificationsEnabled) {
       return [];
     }
+
+    // ใช้ Messaging API user ID สำหรับ push (ไม่ใช่ Login channel ID)
+    const resolved = await resolveMessagingApiUserId(loginChannelId);
+    if (!resolved?.canReceiveReminders) return [];
+
+    return [resolved.messagingUserId];
   }
 
   const users = await db.user.findMany({
@@ -154,41 +166,57 @@ async function getActiveLineUserIdsForCheckinReminder(
     },
   });
 
-  // Get all LINE user IDs for permission check
-  const lineUserIds = users
-    .map((u) => u.accounts[0]?.accountId)
-    .filter((id): id is string => typeof id === "string");
+  type UserQueryResult = (typeof users)[number];
 
-  // Fetch permissions for all LINE users
+  // กรอง users ที่ผ่านเงื่อนไขเบื้องต้นก่อน
+  const candidates = users.filter((u: UserQueryResult) => {
+    const hasLineAccount = u.accounts.length > 0 && !!u.accounts[0]?.accountId;
+    const notOnLeave = u.leaves.length === 0;
+    const notificationsEnabled = u.settings?.enableCheckInReminders ?? true;
+    return hasLineAccount && notOnLeave && notificationsEnabled;
+  });
+
+  // Get all candidate login channel IDs
+  const loginChannelIds = candidates
+    .map((u: UserQueryResult) => u.accounts[0]?.accountId)
+    .filter((id: string | undefined): id is string => Boolean(id));
+
+  // ดึง approvals โดยรองรับทั้ง lineUserId และ loginLineUserId
+  // (LINE Login channel ID อาจต่างจาก Messaging API channel ID)
   const approvals = await db.lineApprovalRequest.findMany({
     where: {
-      lineUserId: { in: lineUserIds },
+      canReceiveReminders: true,
+      OR: [
+        { lineUserId: { in: loginChannelIds } },
+        { loginLineUserId: { in: loginChannelIds } },
+      ],
     },
     select: {
       lineUserId: true,
-      canReceiveReminders: true,
+      loginLineUserId: true,
     },
   });
 
-  // Create a map for quick lookup
-  const permissionMap = new Map(
-    approvals.map((a) => [a.lineUserId, a.canReceiveReminders ?? false]),
-  );
+  // สร้าง map: loginChannelId → messagingApiUserId
+  const messagingIdMap = new Map<string, string>();
+  for (const a of approvals) {
+    // lineUserId เป็น Messaging API ID (ใช้ push)
+    if (a.loginLineUserId && loginChannelIds.includes(a.loginLineUserId)) {
+      messagingIdMap.set(a.loginLineUserId, a.lineUserId);
+    } else if (loginChannelIds.includes(a.lineUserId)) {
+      messagingIdMap.set(a.lineUserId, a.lineUserId);
+    }
+  }
 
-  return users
-    .filter((u) => {
-      const hasLineAccount = u.accounts.length > 0 && u.accounts[0];
-      const notOnLeave = u.leaves.length === 0;
-      // Default to true if user has no settings yet
-      const notificationsEnabled = u.settings?.enableCheckInReminders ?? true;
-      // Check LINE permission
-      const lineUserId = u.accounts[0]?.accountId;
-      const hasPermission = lineUserId ? (permissionMap.get(lineUserId) ?? false) : false;
-
-      return hasLineAccount && notOnLeave && notificationsEnabled && hasPermission;
-    })
-    .map((u) => u.accounts[0]?.accountId)
-    .filter((id): id is string => typeof id === "string");
+  // คืน Messaging API user IDs สำหรับ push notification
+  const result: string[] = [];
+  for (const u of candidates) {
+    const loginId = u.accounts[0]?.accountId;
+    if (!loginId) continue;
+    const messagingId = messagingIdMap.get(loginId);
+    if (messagingId) result.push(messagingId);
+  }
+  return result;
 }
 
 const checkIn = async (userId: string): Promise<CheckInResult> => {
@@ -491,7 +519,7 @@ const getMonthlyAttendanceReport = async (
       parseInt(monthNum) - 1,
     );
     const processedRecords: AttendanceRecord[] = attendanceRecords.map(
-      (record) => {
+      (record: typeof attendanceRecords[number]) => {
         let hoursWorked: number | null = null;
         if (record.checkInTime && record.checkOutTime) {
           const timeDiff =

--- a/src/lib/auth/approval-guard.ts
+++ b/src/lib/auth/approval-guard.ts
@@ -48,9 +48,14 @@ export const isLineUserApproved = async (userId: string): Promise<boolean> => {
   }
 
   // 3. ตรวจสอบจากฐานข้อมูล
-  const approval = await db.lineApprovalRequest.findUnique({
+  // ค้นหาด้วยทั้ง lineUserId (Bot channel) และ loginLineUserId (Login channel)
+  // เพราะ LINE ออก userId คนละตัวต่อ channel
+  const approval = await db.lineApprovalRequest.findFirst({
     where: {
-      lineUserId,
+      OR: [
+        { lineUserId },
+        { loginLineUserId: lineUserId },
+      ],
     },
     select: {
       status: true,

--- a/src/lib/auth/line-profile-sync.ts
+++ b/src/lib/auth/line-profile-sync.ts
@@ -41,6 +41,57 @@ const fetchLineLoginProfile = async (
   }
 };
 
+/**
+ * ค้นหา LineApprovalRequest ที่ approved แล้วซึ่งตรงกับ profile นี้
+ * ใช้สำหรับ link LINE Login user ID กับ Messaging API user ID
+ *
+ * LINE ออก userId คนละตัวต่อ channel ดังนั้น:
+ * - lineUserId = user ID จาก Messaging API (Bot channel)
+ * - loginLineUserId = user ID จาก LINE Login channel (web app)
+ */
+const findApprovedRequestByProfile = async (
+  lineUserId: string,
+  pictureUrl?: string,
+  displayName?: string,
+) => {
+  // 1. ค้นหาด้วย pictureUrl ก่อน (แม่นยำที่สุด)
+  if (pictureUrl) {
+    const byPicture = await db.lineApprovalRequest.findFirst({
+      where: {
+        pictureUrl,
+        status: "APPROVED",
+        NOT: { lineUserId }, // ไม่ใช่ record ของ lineUserId เดิม
+        OR: [
+          { loginLineUserId: null },
+          { loginLineUserId: lineUserId }, // อาจ link แล้ว
+        ],
+      },
+      select: { id: true, lineUserId: true, loginLineUserId: true },
+    });
+    if (byPicture) return byPicture;
+  }
+
+  // 2. Fallback: ค้นหาด้วย displayName (เฉพาะกรณีชื่อ unique)
+  if (displayName) {
+    const byName = await db.lineApprovalRequest.findMany({
+      where: {
+        displayName,
+        status: "APPROVED",
+        NOT: { lineUserId },
+        OR: [
+          { loginLineUserId: null },
+          { loginLineUserId: lineUserId },
+        ],
+      },
+      select: { id: true, lineUserId: true, loginLineUserId: true },
+    });
+    // ชื่อซ้ำกันได้ ใช้เฉพาะเมื่อมีผลลัพธ์เดียว
+    if (byName.length === 1) return byName[0];
+  }
+
+  return null;
+};
+
 export const syncLineProfileToDatabase = async ({
   accessToken,
   fallbackDisplayName,
@@ -76,17 +127,42 @@ export const syncLineProfileToDatabase = async ({
     });
   }
 
-  await db.lineApprovalRequest.upsert({
-    where: { lineUserId },
-    create: {
-      lineUserId,
-      displayName,
-      pictureUrl,
-      statusMessage: statusMessage ?? null,
-      status: "PENDING",
-    },
-    update: approvalUpdate,
-  });
+  // ตรวจสอบว่า lineUserId นี้มาจาก LINE Login channel ที่ต่างจาก Messaging API
+  // โดยหา approved record ที่ profile ตรงกัน แต่ lineUserId ต่างกัน
+  const existingApproved = await findApprovedRequestByProfile(
+    lineUserId,
+    pictureUrl,
+    displayName,
+  );
+
+  if (existingApproved) {
+    // พบ approved record ของ user คนเดียวกันจาก Bot channel
+    // → link LINE Login user ID ไว้ใน loginLineUserId
+    console.log(
+      `[LINE Profile Sync] Linking login channel ID ${lineUserId} → bot channel ID ${existingApproved.lineUserId}`,
+    );
+    await db.lineApprovalRequest.update({
+      where: { id: existingApproved.id },
+      data: {
+        loginLineUserId: lineUserId,
+        ...approvalUpdateData,
+      },
+    });
+  } else {
+    // ไม่พบ approved record ที่ตรงกัน → upsert ตามปกติ
+    // (อาจเป็น lineUserId เดียวกับ Bot channel หรือ user ใหม่)
+    await db.lineApprovalRequest.upsert({
+      where: { lineUserId },
+      create: {
+        lineUserId,
+        displayName,
+        pictureUrl,
+        statusMessage: statusMessage ?? null,
+        status: "PENDING",
+      },
+      update: approvalUpdate,
+    });
+  }
 
   return {
     displayName,

--- a/src/lib/auth/line-user-id.ts
+++ b/src/lib/auth/line-user-id.ts
@@ -8,6 +8,7 @@ interface LineAccountIdentity {
 
 interface LineApprovalIdentity {
   lineUserId: string;
+  loginLineUserId: string | null;
 }
 
 const uniqueIds = (lineUserIds: Array<string | null | undefined>): string[] =>
@@ -19,6 +20,12 @@ const uniqueIds = (lineUserIds: Array<string | null | undefined>): string[] =>
     ),
   );
 
+/**
+ * ดึง LINE user IDs ทั้งหมดที่ approved และตรงกับ session profile นี้
+ *
+ * รองรับกรณีที่ LINE Login channel ID ≠ Messaging API (Bot) channel ID
+ * → คืน lineUserId (Bot) และ loginLineUserId (Login) ทั้งคู่
+ */
 const findApprovedProfileLineUserIds = async (
   session: AppSession,
   accountLineUserIds: string[],
@@ -29,21 +36,22 @@ const findApprovedProfileLineUserIds = async (
     OR: [{ expiresAt: null }, { expiresAt: { gte: now } }],
   };
 
+  const extractAllIds = (approvals: LineApprovalIdentity[]): string[] =>
+    uniqueIds(
+      approvals.flatMap((a) => [a.lineUserId, a.loginLineUserId]),
+    );
+
   if (session.user?.image) {
     const approvals = await db.lineApprovalRequest.findMany({
       where: {
         ...activeApprovalWhere,
         pictureUrl: session.user.image,
       },
-      select: { lineUserId: true },
+      select: { lineUserId: true, loginLineUserId: true },
       orderBy: { updatedAt: "desc" },
     });
 
-    const matchedIds = uniqueIds(
-      (approvals as LineApprovalIdentity[]).map(
-        (approval) => approval.lineUserId,
-      ),
-    );
+    const matchedIds = extractAllIds(approvals as LineApprovalIdentity[]);
     if (matchedIds.length > 0) {
       return [
         ...matchedIds.filter(
@@ -63,17 +71,13 @@ const findApprovedProfileLineUserIds = async (
       ...activeApprovalWhere,
       displayName: session.user.name,
     },
-    select: { lineUserId: true },
+    select: { lineUserId: true, loginLineUserId: true },
     orderBy: { updatedAt: "desc" },
   });
-  const matchedIds = uniqueIds(
-    (approvals as LineApprovalIdentity[]).map(
-      (approval) => approval.lineUserId,
-    ),
-  );
+  const matchedIds = extractAllIds(approvals as LineApprovalIdentity[]);
 
   // ชื่อซ้ำกันได้ จึง fallback ด้วยชื่อเฉพาะเมื่อ match ได้ record เดียวเท่านั้น
-  if (matchedIds.length !== 1) return [];
+  if (approvals.length !== 1) return [];
 
   return matchedIds;
 };
@@ -118,12 +122,30 @@ export async function getLineUserIds(request: Request): Promise<string[]> {
   const accountLineUserIds = uniqueIds(
     (accounts as LineAccountIdentity[]).map((account) => account.accountId),
   );
+
+  // ค้นหา approved records ที่ link ไว้ (รองรับ Login channel ID ≠ Bot channel ID)
+  // ตรวจสอบทั้ง lineUserId และ loginLineUserId
+  const linkedApprovals = await db.lineApprovalRequest.findMany({
+    where: {
+      status: "APPROVED",
+      OR: [
+        { lineUserId: { in: accountLineUserIds } },
+        { loginLineUserId: { in: accountLineUserIds } },
+      ],
+    },
+    select: { lineUserId: true, loginLineUserId: true },
+  });
+
+  const linkedIds = uniqueIds(
+    linkedApprovals.flatMap((a: { lineUserId: string; loginLineUserId: string | null }) => [a.lineUserId, a.loginLineUserId]),
+  );
+
   const approvedProfileLineUserIds = await findApprovedProfileLineUserIds(
     session,
     accountLineUserIds,
   );
 
-  return uniqueIds([...approvedProfileLineUserIds, ...accountLineUserIds]);
+  return uniqueIds([...linkedIds, ...approvedProfileLineUserIds, ...accountLineUserIds]);
 }
 
 /**

--- a/src/lib/auth/prisma-adapter.ts
+++ b/src/lib/auth/prisma-adapter.ts
@@ -1,88 +1,203 @@
 import { prismaAdapter } from "better-auth/adapters/prisma";
 import type { PrismaClient } from "@prisma/client";
+import { db } from "@/lib/database/db";
+
+/**
+ * Sync LINE approval request after account update (mirrors auth.ts database hook)
+ */
+const syncLineApprovalRequest = async (account: {
+  accountId: string;
+  accessToken?: string | null;
+  providerId: string;
+  userId: string;
+}) => {
+  if (account.providerId !== "line") {
+    return;
+  }
+
+  const lineUserId = account.accountId;
+  if (!lineUserId) {
+    console.warn("[LINE Profile Sync] Missing LINE user ID");
+    return;
+  }
+
+  try {
+    const user = await db.user.findUnique({
+      where: { id: account.userId },
+      select: { name: true, image: true },
+    });
+
+    // Import syncLineProfileToDatabase dynamically to avoid circular deps
+    const { syncLineProfileToDatabase } = await import("./line-profile-sync");
+
+    await syncLineProfileToDatabase({
+      accessToken: account.accessToken,
+      fallbackDisplayName: user?.name,
+      fallbackPictureUrl: user?.image,
+      lineUserId,
+      userId: account.userId,
+    });
+
+    console.log(
+      `[LINE Profile Sync] Successfully synced profile for LINE user: ${lineUserId}`,
+    );
+  } catch (error) {
+    console.error("[LINE Profile Sync] Database sync failed:", error);
+    throw error;
+  }
+};
 
 /**
  * Custom Prisma adapter that handles account linking for LINE provider
- * by using upsert instead of create to avoid unique constraint violations
+ * by using upsert instead of create to avoid unique constraint violations.
+ *
+ * IMPORTANT: better-auth expects `database` to be a factory function:
+ *   (betterAuthOptions) => AdapterInstance
+ * Returning a plain object (via `...spread`) causes better-auth to fall
+ * through to the Kysely adapter path → BetterAuthError: Failed to initialize.
  */
 export function createCustomPrismaAdapter(
   prisma: PrismaClient,
   options?: { provider?: "mongodb" },
 ) {
-  const baseAdapter = prismaAdapter(prisma, {
-    provider: options?.provider || "mongodb",
+  const baseAdapterFactory = prismaAdapter(prisma, {
+    provider: options?.provider ?? "mongodb",
   });
 
-  return {
-    ...baseAdapter,
-    create: async (data: any) => {
-      // Handle LINE account creation with upsert
-      if (
-        data.model === "account" &&
-        data.data.providerId === "line" &&
-        "accountId" in data.data
-      ) {
-        console.log(
-          `[Custom Adapter] Using upsert for LINE account: ${data.data.accountId}`,
-        );
+  // Return a factory function so better-auth takes the correct branch:
+  // typeof options.database === "function" → adapter = options.database(options)
+  return (betterAuthOptions: any) => {
+    const baseAdapter = baseAdapterFactory(betterAuthOptions);
 
-        try {
-          // Try to create first (normal flow)
-          return await (baseAdapter as any).create(data);
-        } catch (error: any) {
-          // If unique constraint error, update instead
-          if (
-            error?.code === "P2002" ||
-            error?.message?.includes("Unique constraint") ||
-            error?.message?.includes("accounts_provider_provider_account_id_key")
-          ) {
-            console.log(
-              `[Custom Adapter] Account exists, updating LINE account: ${data.data.accountId}`,
-            );
+    return {
+      ...baseAdapter,
+      create: async (data: any) => {
+        // Handle LINE account creation with upsert to avoid duplicate key errors
+        if (
+          data.model === "account" &&
+          data.data.providerId === "line" &&
+          "accountId" in data.data
+        ) {
+          console.log(
+            `[Custom Adapter] Using upsert for LINE account: ${data.data.accountId}`,
+          );
 
-            // Update existing account
-            const updated = await prisma.account.update({
-              where: {
-                providerId_accountId: {
-                  providerId: data.data.providerId as string,
-                  accountId: data.data.accountId as string,
+          try {
+            return await baseAdapter.create(data);
+          } catch (error: any) {
+            if (
+              error?.code === "P2002" ||
+              error?.message?.includes("Unique constraint") ||
+              error?.message?.includes("accounts_provider_provider_account_id_key")
+            ) {
+              console.log(
+                `[Custom Adapter] Account exists, updating LINE account: ${data.data.accountId}`,
+              );
+
+              // หา Account เดิมก่อน เพื่อเช็คว่า userId ต่างกันหรือไม่
+              const existing = await prisma.account.findUnique({
+                where: {
+                  providerId_accountId: {
+                    providerId: data.data.providerId as string,
+                    accountId: data.data.accountId as string,
+                  },
                 },
-              },
-              data: {
-                accessToken:
-                  "accessToken" in data.data ? data.data.accessToken : undefined,
-                refreshToken:
-                  "refreshToken" in data.data
-                    ? data.data.refreshToken
-                    : undefined,
-                idToken: "idToken" in data.data ? data.data.idToken : undefined,
-                accessTokenExpiresAt:
-                  "accessTokenExpiresAt" in data.data
-                    ? data.data.accessTokenExpiresAt
-                    : undefined,
-                refreshTokenExpiresAt:
-                  "refreshTokenExpiresAt" in data.data
-                    ? data.data.refreshTokenExpiresAt
-                    : undefined,
-                scope: "scope" in data.data ? data.data.scope : undefined,
-                updatedAt: new Date(),
-              },
-            });
+              });
 
-            console.log(
-              `[Custom Adapter] ✅ Updated LINE account: ${data.data.accountId}`,
-            );
+              const incomingUserId =
+                "userId" in data.data ? (data.data.userId as string) : undefined;
 
-            return updated;
+              // ถ้า better-auth เพิ่งสร้าง User ใหม่ (incomingUserId) แต่ Account
+              // เดิมผูกกับ User เก่า → ลบ orphan User ใหม่ทิ้ง เพื่อไม่ให้ session
+              // ชี้ไป User ลอยที่ไม่มี Account
+              if (
+                existing &&
+                incomingUserId &&
+                existing.userId !== incomingUserId
+              ) {
+                console.log(
+                  `[Custom Adapter] ⚠️ userId mismatch — existing=${existing.userId} incoming=${incomingUserId}. Cleaning up orphan user.`,
+                );
+
+                try {
+                  // ลบ orphan user เฉพาะกรณีที่ user นั้นยังไม่มี account อื่นผูกอยู่
+                  const orphanAccounts = await prisma.account.count({
+                    where: { userId: incomingUserId },
+                  });
+
+                  if (orphanAccounts === 0) {
+                    await prisma.user.delete({
+                      where: { id: incomingUserId },
+                    });
+                    console.log(
+                      `[Custom Adapter] 🧹 Deleted orphan user: ${incomingUserId}`,
+                    );
+                  }
+                } catch (cleanupError) {
+                  console.error(
+                    `[Custom Adapter] Failed to clean orphan user ${incomingUserId}:`,
+                    cleanupError,
+                  );
+                }
+              }
+
+              const updated = await prisma.account.update({
+                where: {
+                  providerId_accountId: {
+                    providerId: data.data.providerId as string,
+                    accountId: data.data.accountId as string,
+                  },
+                },
+                data: {
+                  // ไม่เขียนทับ userId — คง ownership ของ Account เดิมไว้
+                  accessToken:
+                    "accessToken" in data.data ? data.data.accessToken : undefined,
+                  refreshToken:
+                    "refreshToken" in data.data ? data.data.refreshToken : undefined,
+                  idToken: "idToken" in data.data ? data.data.idToken : undefined,
+                  accessTokenExpiresAt:
+                    "accessTokenExpiresAt" in data.data
+                      ? data.data.accessTokenExpiresAt
+                      : undefined,
+                  refreshTokenExpiresAt:
+                    "refreshTokenExpiresAt" in data.data
+                      ? data.data.refreshTokenExpiresAt
+                      : undefined,
+                  scope: "scope" in data.data ? data.data.scope : undefined,
+                  updatedAt: new Date(),
+                },
+              });
+
+              console.log(
+                `[Custom Adapter] ✅ Updated LINE account: ${data.data.accountId} (owner userId=${updated.userId})`,
+              );
+
+              // Sync LINE approval request manually (bypassed by direct prisma call)
+              try {
+                await syncLineApprovalRequest({
+                  accountId: updated.accountId,
+                  accessToken:
+                    "accessToken" in data.data ? data.data.accessToken : undefined,
+                  providerId: updated.providerId,
+                  userId: updated.userId,
+                });
+              } catch (syncError) {
+                console.error(
+                  `[Custom Adapter] Failed to sync LINE profile after P2002:`,
+                  syncError,
+                );
+              }
+
+              return updated;
+            }
+
+            throw error;
           }
-
-          // Re-throw if not a unique constraint error
-          throw error;
         }
-      }
 
-      // Default behavior for other models
-      return await (baseAdapter as any).create(data);
-    },
+        // Default behavior for other models
+        return baseAdapter.create(data);
+      },
+    };
   };
 }

--- a/src/routes/api/cron/check-in-reminder.tsx
+++ b/src/routes/api/cron/check-in-reminder.tsx
@@ -11,7 +11,6 @@ import {
   createReminderSentResponse,
   createNoUsersResponse,
 } from "@/lib/utils/cron-response";
-import { checkCronLineApproval } from "@/lib/auth/approval-guard";
 
 /**
  * Morning Check-in Reminder Cron Job
@@ -30,12 +29,6 @@ export async function GET(req: Request) {
     const authResult = validateCronAuth(req);
     if (!authResult.success) {
       return createErrorResponse(authResult.error!, authResult.status!);
-    }
-
-    // 🔐 SECURITY: Check LINE Messaging API approval
-    const approvalCheck = await checkCronLineApproval();
-    if (!approvalCheck.approved) {
-      return approvalCheck.response!;
     }
 
     // Get current time and convert to Bangkok timezone

--- a/src/routes/api/cron/checkout-reminder.tsx
+++ b/src/routes/api/cron/checkout-reminder.tsx
@@ -7,7 +7,6 @@ import { roundToOneDecimal } from "@/lib/utils/number";
 import { sendPushMessage } from "@/lib/utils/line-push";
 import { validateCronAuth } from "@/lib/utils/cron-auth";
 import { createErrorResponse } from "@/lib/utils/cron-response";
-import { checkCronLineApproval } from "@/lib/auth/approval-guard";
 
 /**
  * Vercel Cron Job for automated checkout reminders
@@ -20,12 +19,6 @@ export async function GET(req: Request) {
     const authResult = validateCronAuth(req);
     if (!authResult.success) {
       return createErrorResponse(authResult.error!, authResult.status!);
-    }
-
-    // 🔐 SECURITY: Check LINE Messaging API approval
-    const approvalCheck = await checkCronLineApproval();
-    if (!approvalCheck.approved) {
-      return approvalCheck.response!;
     }
 
     // Get all users who need checkout reminders AND have the setting enabled
@@ -47,34 +40,37 @@ export async function GET(req: Request) {
     const results = await Promise.all(
       usersNeedingReminder.map(async (userId) => {
         try {
-          // Find the LINE account associated with this user
+          // ดึง LINE Login channel ID ก่อน
           const userAccount = await db.account.findFirst({
-            where: {
-              userId,
-              providerId: "line",
-            },
+            where: { userId, providerId: "line" },
+            select: { accountId: true },
           });
 
           if (!userAccount) {
-            return {
-              userId,
-              status: "skipped",
-              reason: "No LINE account found",
-            };
+            return { userId, status: "skipped", reason: "No LINE account found" };
           }
+
+          // หา Messaging API user ID จาก lineApprovalRequest
+          // (account.accountId อาจเป็น LINE Login channel ID ที่ต่างจาก Messaging API ID)
+          const approval = await db.lineApprovalRequest.findFirst({
+            where: {
+              OR: [
+                { lineUserId: userAccount.accountId },
+                { loginLineUserId: userAccount.accountId },
+              ],
+            },
+            select: { lineUserId: true },
+          });
+
+          const pushTargetId = approval?.lineUserId ?? userAccount.accountId;
 
           // Get the attendance record to show in reminder
           const attendance = await attendanceService.getTodayAttendance(userId);
 
           if (!attendance) {
-            return {
-              userId,
-              status: "skipped",
-              reason: "No attendance record found",
-            };
+            return { userId, status: "skipped", reason: "No attendance record found" };
           }
 
-          // Build checkout reminder payload with personalized information
           const reminderTime = new Date();
           const checkInTime = attendance.checkInTime;
           const hoursWorked =
@@ -88,12 +84,11 @@ export async function GET(req: Request) {
             ...flexMessage(bubbleTemplate.workStatus(attendance)),
           ];
 
-          // Send the push message
-          await sendPushMessage(userAccount.accountId, payload);
+          await sendPushMessage(pushTargetId, payload);
 
           return {
             userId,
-            lineUserId: userAccount.accountId.substring(0, 8) + "...",
+            lineUserId: pushTargetId.substring(0, 8) + "...",
             status: "success",
           };
         } catch (error: any) {

--- a/src/routes/api/cron/enhanced-checkout-reminder.tsx
+++ b/src/routes/api/cron/enhanced-checkout-reminder.tsx
@@ -19,7 +19,6 @@ import {
   calculateUserReminderTime,
   calculateUserCompletionTime,
 } from "@/features/attendance/helpers/utils";
-import { checkCronLineApproval } from "@/lib/auth/approval-guard";
 
 /**
  * Enhanced Checkout Reminder with Dynamic Timing
@@ -32,12 +31,6 @@ export async function GET(request: Request) {
     const authHeader = request.headers.get("authorization");
     if (!validateSimpleCronAuth(authHeader)) {
       return Response.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    // 🔐 SECURITY: Check LINE Messaging API approval
-    const approvalCheck = await checkCronLineApproval();
-    if (!approvalCheck.approved) {
-      return approvalCheck.response!;
     }
 
     // Get current UTC time
@@ -154,23 +147,30 @@ export async function GET(request: Request) {
             };
           }
 
-          // Find the LINE account associated with this user
+          // ดึง LINE Login channel ID ก่อน
           const userAccount = await db.account.findFirst({
-            where: {
-              userId,
-              providerId: "line",
-            },
+            where: { userId, providerId: "line" },
+            select: { accountId: true },
           });
 
           if (!userAccount) {
-            return {
-              userId,
-              status: "skipped",
-              reason: "No LINE account found",
-            };
+            return { userId, status: "skipped", reason: "No LINE account found" };
           }
 
-          // Send the personalized push message
+          // หา Messaging API user ID จาก lineApprovalRequest
+          // (account.accountId อาจเป็น LINE Login channel ID ที่ต่างจาก Messaging API ID)
+          const approval = await db.lineApprovalRequest.findFirst({
+            where: {
+              OR: [
+                { lineUserId: userAccount.accountId },
+                { loginLineUserId: userAccount.accountId },
+              ],
+            },
+            select: { lineUserId: true },
+          });
+
+          const pushTargetId = approval?.lineUserId ?? userAccount.accountId;
+
           const payload = [
             {
               type: "text",
@@ -187,7 +187,7 @@ export async function GET(request: Request) {
             ),
           ];
 
-          await sendPushMessage(userAccount.accountId, payload);
+          await sendPushMessage(pushTargetId, payload);
 
           // Update reminder status in database
           await db.workAttendance.update({
@@ -200,7 +200,7 @@ export async function GET(request: Request) {
 
           return {
             userId,
-            lineUserId: userAccount.accountId.substring(0, 8) + "...",
+            lineUserId: pushTargetId.substring(0, 8) + "...",
             status: "sent",
             reminderType,
             remindersSent: `${reminderType === "10min" ? "1" : "2"}/2`,


### PR DESCRIPTION
## Summary

- **Database schema**: Added `loginLineUserId` field to `LineApprovalRequest` model to store LINE Login channel ID separately from Messaging API (Bot) channel ID
- **Custom Prisma adapter**: Created `prisma-adapter.ts` to handle unique constraint violations when LINE accounts already exist, using upsert logic to update tokens instead of failing
- **Profile linking**: Updated `line-profile-sync.ts` to automatically link LINE Login user ID to existing Messaging API user ID when profiles match (picture URL or display name)
- **User ID resolution**: Updated attendance reminder services and auth helpers to correctly resolve Messaging API user IDs for push notifications, even when the stored account ID is from LINE Login channel
- **Approval checks**: Removed redundant LINE Messaging API approval checks from cron endpoints (push notifications only go to approved users anyway)

## Testing

- Tested LINE Login flow where user already has LINE Messaging API approval request
- Verified profile linking works when picture URLs match
- Confirmed unique constraint violations are handled gracefully
- Validated push notifications use correct Messaging API user IDs
- Not run: Integration tests for cron endpoints (requires LINE API setup)