### PR TITLE
feat(auth): upgrade to Prisma 7 with PostgreSQL and LINE account linking

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -79,5 +79,14 @@ export default defineConfig(({ mode }) => {
     server: {
       allowedHosts,
     },
+    build: {
+      rollupOptions: {
+        external: [
+          /^@prisma\/client/,
+          /^@prisma\/adapter-pg/,
+          /^pg/,
+        ],
+      },
+    },
   };
 });


### PR DESCRIPTION
## Summary

- **Prisma 7 upgrade**: Migrated from Prisma 6 to Prisma 7 with PostgreSQL adapter (`@prisma/adapter-pg`)
- **LINE account linking**: Added support for linking LINE Messaging API user IDs with LINE Login accounts, enabling account merging
- **Custom auth adapter**: Implemented `PrismaBetterAuth2Adapter` to handle LINE unique constraints (LINE Login user ID + Messaging API user ID)
- **Database migration**: Migrated from MongoDB to PostgreSQL with comprehensive migration scripts
- **Documentation**: Added detailed guides for LINE account linking, bot channel setup, and user ID debugging
- **Build updates**: Updated Docker configurations, Vite bundling exclusions, and script paths
- **Admin seeding**: Added admin role seeding script for initial setup

## Testing

- Not run