### PR TITLE
feat: migrate from MongoDB to PostgreSQL with Prisma 7 and LINE account linking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -109,9 +109,10 @@ COPY package.json bun.lock ./
 RUN --mount=type=cache,target=/root/.bun/install/cache \
     bun install --production --frozen-lockfile
 
-COPY --from=build /app/node_modules/.prisma ./node_modules/.prisma
+# Copy Prisma dependencies and generated client
 COPY --from=build /app/node_modules/@prisma ./node_modules/@prisma
 COPY --from=build /app/node_modules/pg ./node_modules/pg
+COPY --from=build /app/prisma ./node_modules/.prisma
 
 ###################
 # 🚀 RUNTIME STAGE
@@ -150,7 +151,7 @@ COPY --from=build --chown=appuser:appgroup /app/scripts ./scripts
 RUN chmod +x ./scripts/devops/docker-entrypoint.sh ./scripts/monitoring/health-check.sh && \
     test -f dist/server/server.js || (echo "❌ TanStack Start server bundle missing" && exit 1) && \
     test -d dist/client || (echo "❌ TanStack Start client bundle missing" && exit 1) && \
-    (test -d prisma/generated/client || test -d node_modules/@prisma/client) || (echo "❌ Prisma Client missing" && exit 1) && \
+    (test -f node_modules/.prisma/client.ts || test -f prisma/generated/client.ts || test -f node_modules/@prisma/client/index.js) || (echo "❌ Prisma Client missing" && exit 1) && \
     echo "✅ Runtime dependencies verified"
 
 USER appuser

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -53,7 +53,7 @@
         "./src/lib/validation/*"
       ],
       "@prisma/client": [
-        "./prisma/generated/client"
+        "./prisma/generated"
       ]
     },
     "types": [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -72,7 +72,7 @@ export default defineConfig(({ mode }) => {
     resolve: {
       alias: {
         "@": path.resolve(dirname, "src"),
-        "@prisma/client": path.resolve(dirname, "prisma/generated/client"),
+        "@prisma/client": path.resolve(dirname, "prisma/generated"),
       },
       tsconfigPaths: true,
     },


### PR DESCRIPTION
## Summary

- **Database Migration**: Migrated from MongoDB to PostgreSQL using Prisma 7 adapter
- **Prisma Upgrade**: Upgraded from Prisma 6 to Prisma 7 with `@prisma/adapter-pg`
- **LINE Account Linking**: Added LINE Messaging API user ID linking and account merge functionality
- **Unique Constraint Handling**: Implemented custom Prisma adapter to handle LINE account unique constraints
- **Build Configuration**: Updated Docker configurations, Vite bundling exclusions for Prisma packages, and script paths
- **Documentation**: Added comprehensive guides for LINE account linking, bot channel setup, and user ID debugging
- **Admin Tools**: Added admin role seeding script and old LINE account cleanup utilities
- **Migration Scripts**: Created MongoDB to PostgreSQL migration tool with data transformation

## Testing

- [ ] Database migration completes successfully from MongoDB to PostgreSQL
- [ ] LINE Login authentication flow works with PostgreSQL backend
- [ ] LINE Messaging API user ID linking functions correctly
- [ ] Account merge process handles duplicate users appropriately
- [ ] Admin role seeding script executes without errors
- [ ] Docker containers build and run with new Prisma 7 configuration
- [ ] Vite development server starts correctly with Prisma packages excluded from bundling
- [ ] Health check endpoints respond successfully
- [ ] All unique constraint violations are handled gracefully by custom adapter