### PR TITLE
fix: upgrade to Prisma 7 with PostgreSQL adapter and fix LINE auth unique constraints

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -22,6 +22,7 @@ bun.lockb.backup*
 # =============================================================================
 node_modules/.prisma/
 node_modules/@prisma/engines/
+prisma/generated
 # Note: Keep prisma/ folder - schema.prisma is needed
 # Note: migrations/ excluded for MongoDB (no migrations)
 prisma/migrations/

--- a/Dockerfile
+++ b/Dockerfile
@@ -112,7 +112,8 @@ RUN --mount=type=cache,target=/root/.bun/install/cache \
 # Copy Prisma dependencies
 COPY --from=build /app/node_modules/@prisma ./node_modules/@prisma
 COPY --from=build /app/node_modules/pg ./node_modules/pg
-COPY --from=build /app/node_modules/.prisma ./node_modules/.prisma
+RUN mkdir -p ./node_modules/.prisma
+COPY --from=build /app/prisma/generated ./node_modules/.prisma/client
 
 ###################
 # 🚀 RUNTIME STAGE
@@ -145,8 +146,6 @@ COPY --from=prod-deps --chown=appuser:appgroup /app/node_modules ./node_modules
 COPY --from=build --chown=appuser:appgroup /app/prisma ./prisma
 COPY --from=build --chown=appuser:appgroup /app/prisma.config.ts ./prisma.config.ts
 
-# Create symlink for custom location (prisma/generated → node_modules/.prisma/client)
-RUN cd prisma && ln -sf ../node_modules/.prisma/client generated && cd ..
 COPY --from=build --chown=appuser:appgroup /app/package.json ./package.json
 COPY --from=build --chown=appuser:appgroup /app/server.ts ./server.ts
 COPY --from=build --chown=appuser:appgroup /app/scripts ./scripts
@@ -154,7 +153,7 @@ COPY --from=build --chown=appuser:appgroup /app/scripts ./scripts
 RUN chmod +x ./scripts/devops/docker-entrypoint.sh ./scripts/monitoring/health-check.sh && \
     test -f dist/server/server.js || (echo "❌ TanStack Start server bundle missing" && exit 1) && \
     test -d dist/client || (echo "❌ TanStack Start client bundle missing" && exit 1) && \
-    (test -f node_modules/.prisma/default.js || test -f prisma/generated/default.js) || (echo "❌ Prisma Client missing" && exit 1) && \
+    (test -f node_modules/.prisma/client/default.js || test -f prisma/generated/default.js) || (echo "❌ Prisma Client missing" && exit 1) && \
     echo "✅ Runtime dependencies verified"
 
 USER appuser


### PR DESCRIPTION
## Summary

- Upgrades Prisma from v6 to v7 with the `@prisma/adapter-pg` PostgreSQL driver adapter
- Adds a custom Prisma adapter (`src/lib/auth/prisma-adapter.ts`) to gracefully handle unique constraint errors on LINE account linking and merging
- Simplifies LINE auth to use a single canonical user ID and adds duplicate check for DCA records
- Adds `src/lib/auth/account-linking.ts` to support LINE Messaging API user ID linking and account merge flows
- Fixes Docker image to copy Prisma generated client directly instead of symlinking, and updates script paths after reorganisation (`scripts/devops/`, `scripts/monitoring/`, etc.)
- Excludes Prisma packages from Vite bundling to avoid build conflicts
- Adds initial PostgreSQL migration and a MongoDB-to-Postgres migration script
- Reorganises `scripts/` directory into categorised subdirectories (`archive/`, `db/`, `devops/`, `migrations/`, `monitoring/`, `secrets/`, `tests/`)

## Testing

- [ ] LINE Login flow completes without unique constraint errors when the same LINE account logs in a second time
- [ ] LINE Messaging API webhook correctly links user IDs without creating duplicate accounts
- [ ] DCA command rejects duplicate entries for the same day
- [ ] Docker image builds successfully and Prisma client resolves at `node_modules/.prisma/client/default.js`
- [ ] Health check endpoint responds via the updated `scripts/monitoring/health-check.sh` path inside the container
- [ ] Prisma migrations run cleanly against a fresh PostgreSQL database (`prisma migrate deploy`)
- [ ] Vite build completes without bundling errors related to `@prisma/client` or `@prisma/engines`
- [ ] All cron scripts (`docker-entrypoint.sh`, `cron-request.sh`) are executable and resolve from their new paths in the container