### PR TITLE
feat: improve leave form UI with Thai calendar and history

### DIFF
--- a/src/components/attendance/LeaveForm.tsx
+++ b/src/components/attendance/LeaveForm.tsx
@@ -1,43 +1,271 @@
 // src/components/attendance/LeaveForm.tsx
 "use client";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
+import { DayPicker as ThaiDayPicker } from "react-day-picker/buddhist";
 import { useToast } from "@/components/common/ToastProvider";
 import { useSession } from "@/lib/auth/client";
+import { cn } from "@/lib/utils";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import {
-  Calendar,
-  Save,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Calendar as CalendarIcon,
   Cake,
   Palmtree,
   Stethoscope,
   User,
+  Loader2,
+  ChevronLeft,
+  ChevronRight,
+  ClipboardList,
+  Info,
 } from "lucide-react";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface LeaveRecord {
+  id: string;
+  date: string;
+  type: string;
+  reason?: string | null;
+  createdAt: string;
+}
 
 interface LeaveFormProps {
   onSubmit?: () => void;
 }
 
+// ─── Leave type config ────────────────────────────────────────────────────────
+
+const LEAVE_TYPES = [
+  { value: "personal", label: "ลากิจ",    icon: User },
+  { value: "sick",     label: "ลาป่วย",   icon: Stethoscope },
+  { value: "vacation", label: "ลาพักร้อน", icon: Palmtree },
+  { value: "birthday", label: "เดือนเกิด", icon: Cake },
+] as const;
+
+type LeaveTypeValue = (typeof LEAVE_TYPES)[number]["value"];
+
+const LEAVE_TYPE_MAP = Object.fromEntries(
+  LEAVE_TYPES.map((t) => [t.value, t]),
+) as Record<string, (typeof LEAVE_TYPES)[number]>;
+
+// ─── Calendar classNames (Tailwind override, bypasses default react-day-picker CSS) ───
+
+const CALENDAR_CLASSNAMES = {
+  root: "p-3 select-none",
+  months: "flex flex-col",
+  // month เป็น relative parent ของ nav (absolute)
+  month: "relative",
+  month_caption: "flex h-9 w-full items-center justify-center",
+  caption_label: "text-sm font-semibold text-foreground",
+  // nav อยู่บน month_caption ด้วย z-10 เพื่อให้กดได้
+  nav: "absolute inset-x-0 top-0 z-10 flex h-9 items-center justify-between",
+  button_previous: cn(
+    "flex h-7 w-7 items-center justify-center rounded-md",
+    "border border-input bg-background text-foreground",
+    "opacity-60 transition-opacity hover:opacity-100 active:scale-95",
+    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+  ),
+  button_next: cn(
+    "flex h-7 w-7 items-center justify-center rounded-md",
+    "border border-input bg-background text-foreground",
+    "opacity-60 transition-opacity hover:opacity-100 active:scale-95",
+    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+  ),
+  month_grid: "mt-2 w-full border-collapse",
+  weekdays: "flex",
+  weekday:
+    "w-9 py-1 text-center text-[0.75rem] font-normal text-muted-foreground",
+  week: "mt-1 flex w-full",
+  day: "relative p-0",
+  // day_button: base styles + data-* state variants
+  day_button: cn(
+    "inline-flex h-9 w-9 items-center justify-center rounded-full text-sm font-normal",
+    "transition-colors",
+    "hover:bg-accent hover:text-accent-foreground",
+    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+    // selected — primary fill (สูงกว่า today)
+    "data-[selected]:bg-primary data-[selected]:text-primary-foreground",
+    "data-[selected]:hover:bg-primary/90 data-[selected]:hover:text-primary-foreground",
+    // outside month days
+    "data-[outside]:text-muted-foreground data-[outside]:opacity-40",
+    // disabled
+    "data-[disabled]:cursor-not-allowed data-[disabled]:opacity-30",
+  ),
+  // today: ring รอบวันปัจจุบัน (ถ้าเลือกแล้วจะถูก bg-primary ทับ แต่ ring ยังเห็น)
+  today: "ring-2 ring-primary/70 font-bold rounded-full",
+  // modifier ที่เหลือว่าง (handle ใน day_button ด้วย data-*)
+  selected: "",
+  outside: "",
+  disabled: "",
+  hidden: "invisible",
+} as const;
+
+// ─── Date helpers ─────────────────────────────────────────────────────────────
+
+const THAI_MONTHS_LONG = [
+  "มกราคม",
+  "กุมภาพันธ์",
+  "มีนาคม",
+  "เมษายน",
+  "พฤษภาคม",
+  "มิถุนายน",
+  "กรกฎาคม",
+  "สิงหาคม",
+  "กันยายน",
+  "ตุลาคม",
+  "พฤศจิกายน",
+  "ธันวาคม",
+];
+
+const THAI_MONTHS_SHORT = [
+  "ม.ค.",
+  "ก.พ.",
+  "มี.ค.",
+  "เม.ย.",
+  "พ.ค.",
+  "มิ.ย.",
+  "ก.ค.",
+  "ส.ค.",
+  "ก.ย.",
+  "ต.ค.",
+  "พ.ย.",
+  "ธ.ค.",
+];
+
+const THAI_WEEKDAYS = [
+  "อาทิตย์",
+  "จันทร์",
+  "อังคาร",
+  "พุธ",
+  "พฤหัสบดี",
+  "ศุกร์",
+  "เสาร์",
+];
+
+/** แปลง "yyyy-mm-dd" → Date object (local time zone) */
+function parseDateStr(str: string): Date | undefined {
+  if (!str) return undefined;
+  const [yearStr, monthStr, dayStr] = str.split("-");
+  const year = parseInt(yearStr ?? "", 10);
+  const month = parseInt(monthStr ?? "", 10);
+  const day = parseInt(dayStr ?? "", 10);
+  if (!year || !month || !day) return undefined;
+  return new Date(year, month - 1, day);
+}
+
+/** แปลง Date → "yyyy-mm-dd" */
+function formatDateToStr(date: Date): string {
+  return [
+    date.getFullYear(),
+    String(date.getMonth() + 1).padStart(2, "0"),
+    String(date.getDate()).padStart(2, "0"),
+  ].join("-");
+}
+
+/** แสดงวันที่แบบเต็มภาษาไทย: "วันพฤหัสบดีที่ 18 เมษายน 2569" */
+function formatThaiFullDate(dateStr: string): string {
+  const d = parseDateStr(dateStr);
+  if (!d) return "เลือกวันที่ลา";
+  const weekday = THAI_WEEKDAYS[d.getDay()] ?? "";
+  const day = d.getDate();
+  const buddhistYear = d.getFullYear() + 543;
+  return `วัน${weekday}ที่ ${day} ${THAI_MONTHS_LONG[d.getMonth()] ?? ""} ${buddhistYear}`;
+}
+
+/** แสดงเดือนปีภาษาไทยสำหรับ history navigation: "เมษายน 2569" */
+function getThaiMonthLabel(yyyyMm: string): string {
+  const [yearStr, monthStr] = yyyyMm.split("-");
+  const year = parseInt(yearStr ?? "0", 10);
+  const monthIndex = parseInt(monthStr ?? "1", 10) - 1;
+  return `${THAI_MONTHS_LONG[monthIndex] ?? ""} ${year + 543}`;
+}
+
+/** แสดงวันที่ย่อภาษาไทยสำหรับ history list: "18 เม.ย. 2569" */
+function formatThaiShortDate(dateStr: string): string {
+  const [yearStr, monthStr, dayStr] = dateStr.split("-");
+  const year = parseInt(yearStr ?? "0", 10);
+  const monthIndex = parseInt(monthStr ?? "1", 10) - 1;
+  return `${dayStr} ${THAI_MONTHS_SHORT[monthIndex] ?? ""} ${year + 543}`;
+}
+
+function getTodayStr(): string {
+  const d = new Date();
+  return [
+    d.getFullYear(),
+    String(d.getMonth() + 1).padStart(2, "0"),
+    String(d.getDate()).padStart(2, "0"),
+  ].join("-");
+}
+
+function getCurrentMonthStr(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+}
+
+function shiftMonth(yyyyMm: string, delta: number): string {
+  const [yearStr, monthStr] = yyyyMm.split("-");
+  const d = new Date(
+    parseInt(yearStr ?? "0", 10),
+    parseInt(monthStr ?? "1", 10) - 1 + delta,
+    1,
+  );
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
 export const LeaveForm = ({ onSubmit }: LeaveFormProps) => {
-  const [date, setDate] = useState("");
-  const [type, setType] = useState("personal");
+  const todayStr = getTodayStr();
+  const currentMonthStr = getCurrentMonthStr();
+
+  // Form state
+  const [date, setDate] = useState(todayStr);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [type, setType] = useState<LeaveTypeValue>("personal");
   const [reason, setReason] = useState("");
   const [loading, setLoading] = useState(false);
+
+  // History state
+  const [historyMonth, setHistoryMonth] = useState(currentMonthStr);
+  const [leaves, setLeaves] = useState<LeaveRecord[]>([]);
+  const [historyLoading, setHistoryLoading] = useState(false);
+
   const { showToast } = useToast();
   const { status } = useSession();
 
-  // ตั้งค่า default วันที่ลาเป็นวันนี้เมื่อโหลด component
+  // ─── Fetch leave history ──────────────────────────────────────────────────
+
+  const fetchLeaves = useCallback(
+    async (month: string) => {
+      if (status !== "authenticated") return;
+      setHistoryLoading(true);
+      try {
+        const res = await fetch(`/api/leave?month=${month}`);
+        const data: { success: boolean; leaves?: LeaveRecord[] } =
+          await res.json();
+        if (data.success) setLeaves(data.leaves ?? []);
+      } catch {
+        // silent — ไม่กระทบ form หลัก
+      } finally {
+        setHistoryLoading(false);
+      }
+    },
+    [status],
+  );
+
   useEffect(() => {
-    if (!date) {
-      const today = new Date();
-      const yyyy = today.getFullYear();
-      const mm = String(today.getMonth() + 1).padStart(2, "0");
-      const dd = String(today.getDate()).padStart(2, "0");
-      setDate(`${yyyy}-${mm}-${dd}`);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    void fetchLeaves(historyMonth);
+  }, [historyMonth, fetchLeaves]);
+
+  // ─── Auth redirect ────────────────────────────────────────────────────────
 
   useEffect(() => {
     if (status === "unauthenticated") {
@@ -52,25 +280,20 @@ export const LeaveForm = ({ onSubmit }: LeaveFormProps) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [status]);
 
+  // ─── Submit ───────────────────────────────────────────────────────────────
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (status !== "authenticated") {
       showToast({ title: "กรุณาเข้าสู่ระบบ", type: "error" });
-      setTimeout(() => {
-        if (typeof window !== "undefined") {
-          const callbackUrl = window.location.pathname + window.location.search;
-          window.location.href = `/login?callbackUrl=${encodeURIComponent(callbackUrl)}`;
-        }
-      }, 1200);
+      return;
+    }
+    if (!date) {
+      showToast({ title: "กรุณาเลือกวันที่ลา", type: "warning" });
       return;
     }
     setLoading(true);
     try {
-      if (!date) {
-        showToast({ title: "กรุณาเลือกวันที่ลา", type: "warning" });
-        setLoading(false);
-        return;
-      }
       const res = await fetch("/api/leave", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -79,29 +302,31 @@ export const LeaveForm = ({ onSubmit }: LeaveFormProps) => {
       const isJson = res.headers
         .get("content-type")
         ?.includes("application/json");
-      const data = isJson ? await res.json().catch(() => ({})) : {};
-      if (!res.ok || (data && data.success === false)) {
-        // ใช้ message จาก API เป็นหลัก
+      const data: { success?: boolean; message?: string } = isJson
+        ? await res.json().catch(() => ({}))
+        : {};
+
+      if (!res.ok || data?.success === false) {
         const msg =
           typeof data.message === "string"
             ? data.message
             : "ไม่สามารถบันทึกวันลาได้ กรุณาลองใหม่อีกครั้ง";
         showToast({ title: msg, type: "error" });
-        if (msg === "กรุณาเข้าสู่ระบบ") {
-          setTimeout(() => {
-            if (typeof window !== "undefined") {
-              const callbackUrl =
-                window.location.pathname + window.location.search;
-              window.location.href = `/login?callbackUrl=${encodeURIComponent(callbackUrl)}`;
-            }
-          }, 1200);
-        }
         return;
       }
-      setDate("");
+
+      showToast({ title: "บันทึกวันลาสำเร็จ", type: "success" });
+      setDate(todayStr);
       setType("personal");
       setReason("");
-      showToast({ title: "บันทึกวันลาสำเร็จ", type: "success" });
+
+      const submittedMonth = date.slice(0, 7);
+      if (submittedMonth !== historyMonth) {
+        setHistoryMonth(submittedMonth);
+      } else {
+        void fetchLeaves(submittedMonth);
+      }
+
       onSubmit?.();
     } catch {
       showToast({
@@ -113,134 +338,355 @@ export const LeaveForm = ({ onSubmit }: LeaveFormProps) => {
     }
   };
 
-  const leaveTypes = [
-    {
-      value: "personal",
-      label: "ลากิจ",
-      icon: <User className="h-4 w-4" />,
-    },
-    {
-      value: "sick",
-      label: "ลาป่วย",
-      icon: <Stethoscope className="h-4 w-4" />,
-    },
-    {
-      value: "vacation",
-      label: "ลาพักร้อน",
-      icon: <Palmtree className="h-4 w-4" />,
-    },
-    {
-      value: "birthday",
-      label: "เดือนเกิด",
-      icon: <Cake className="h-4 w-4" />,
-    },
-  ];
+  // ─── Render ───────────────────────────────────────────────────────────────
 
   return (
-    <div className="container mx-auto max-w-4xl px-4 py-8">
+    <div id="leave-page" className="container mx-auto max-w-lg px-4 py-8">
       <div className="space-y-6">
-        {/* Header */}
-        <div className="space-y-2">
-          <h1 className="text-3xl font-bold tracking-tight">แจ้งวันลา</h1>
-          <p className="text-muted-foreground">
-            บันทึกข้อมูลวันลาของคุณ ระบบจะสร้างบันทึกการทำงานอัตโนมัติ
+        {/* ── Header ── */}
+        <div id="leave-header">
+          <h1
+            id="leave-title"
+            className="text-foreground text-2xl font-bold tracking-tight"
+          >
+            แจ้งวันลา
+          </h1>
+          <p id="leave-subtitle" className="text-muted-foreground mt-1 text-sm">
+            ระบบจะสร้างบันทึกการทำงานให้อัตโนมัติเมื่อบันทึกวันลา
           </p>
         </div>
 
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Calendar className="h-5 w-5" />
+        {/* ── Form Card ── */}
+        <Card id="leave-form-card" className="shadow-sm">
+          <CardHeader className="pb-4">
+            <CardTitle
+              id="leave-form-title"
+              className="flex items-center gap-2 text-base"
+            >
+              <CalendarIcon
+                className="text-primary h-4 w-4"
+                aria-hidden="true"
+              />
               ข้อมูลการลา
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <form onSubmit={handleSubmit} className="space-y-6">
-              {/* Date Field */}
-              <div className="space-y-2">
-                <Label htmlFor="leave-date" className="text-sm font-medium">
+            <form
+              id="leave-form"
+              onSubmit={handleSubmit}
+              className="space-y-5"
+              noValidate
+            >
+              {/* ── วันที่ลา ── */}
+              <div id="leave-date-field" className="space-y-1.5">
+                <Label
+                  htmlFor="leave-date-trigger"
+                  className="text-sm font-medium"
+                >
                   วันที่ลา
                 </Label>
-                <input
-                  id="leave-date"
-                  type="date"
-                  value={date}
-                  onChange={(e) => setDate(e.target.value)}
-                  required
-                  className="w-full rounded-md border bg-background px-3 py-1.5 text-sm text-foreground transition focus:outline-none focus:ring-2 focus:ring-primary"
-                />
+
+                <Popover open={pickerOpen} onOpenChange={setPickerOpen}>
+                  <PopoverTrigger asChild>
+                    <button
+                      id="leave-date-trigger"
+                      type="button"
+                      aria-label={`วันที่ลาที่เลือก: ${formatThaiFullDate(date)} กดเพื่อเปลี่ยน`}
+                      aria-expanded={pickerOpen}
+                      aria-haspopup="dialog"
+                      aria-controls="leave-date-popover"
+                      className="border-input bg-background focus-visible:ring-ring flex h-10 w-full items-center gap-2.5 rounded-md border px-3 text-left text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+                    >
+                      <CalendarIcon
+                        className="text-muted-foreground h-4 w-4 shrink-0"
+                        aria-hidden="true"
+                      />
+                      <span className="text-foreground font-medium">
+                        {formatThaiFullDate(date)}
+                      </span>
+                    </button>
+                  </PopoverTrigger>
+
+                  <PopoverContent
+                    id="leave-date-popover"
+                    role="dialog"
+                    aria-label="เลือกวันที่ลา"
+                    className="w-auto p-0"
+                    align="start"
+                    sideOffset={4}
+                  >
+                    <ThaiDayPicker
+                      id="leave-date-calendar"
+                      mode="single"
+                      selected={parseDateStr(date)}
+                      onSelect={(day) => {
+                        if (day) {
+                          setDate(formatDateToStr(day));
+                          setPickerOpen(false);
+                        }
+                      }}
+                      classNames={CALENDAR_CLASSNAMES}
+                      numerals="latn"
+                      autoFocus
+                    />
+                  </PopoverContent>
+                </Popover>
               </div>
 
-              {/* Leave Type Field */}
-              <div className="space-y-3">
-                <Label htmlFor="leave-type" className="text-sm font-semibold">
+              {/* ── ประเภทวันลา ── */}
+              <div id="leave-type-field" className="space-y-2">
+                <Label
+                  id="leave-type-label"
+                  htmlFor="leave-type-grid"
+                  className="text-sm font-medium"
+                >
                   ประเภทวันลา
                 </Label>
-                <div className="grid gap-3 sm:grid-cols-2">
-                  {leaveTypes.map((leaveType) => (
-                    <button
-                      key={leaveType.value}
-                      type="button"
-                      onClick={() => setType(leaveType.value)}
-                      className={`flex h-14 items-center gap-3 rounded-lg border p-3 transition-all ${
-                        type === leaveType.value
-                          ? "bg-primary/10 border-primary text-primary"
-                          : "border-border bg-card hover:bg-accent"
-                      }`}
-                    >
-                      <div
-                        className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-md ${
-                          type === leaveType.value
-                            ? "bg-primary/20 text-primary"
-                            : "bg-muted text-muted-foreground"
-                        }`}
+                <div
+                  id="leave-type-grid"
+                  role="radiogroup"
+                  aria-labelledby="leave-type-label"
+                  className="grid grid-cols-2 gap-2"
+                >
+                  {LEAVE_TYPES.map((lt) => {
+                    const Icon = lt.icon;
+                    const isActive = type === lt.value;
+                    return (
+                      <button
+                        key={lt.value}
+                        id={`leave-type-${lt.value}`}
+                        type="button"
+                        role="radio"
+                        aria-checked={isActive}
+                        onClick={() => setType(lt.value)}
+                        className={cn(
+                          "flex items-center gap-3 rounded-xl border-2 bg-muted/30 p-3 text-left",
+                          "transition-all duration-150",
+                          "focus-visible:ring-ring focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none",
+                          isActive
+                            ? "border-primary"
+                            : "border-border hover:border-primary/40",
+                        )}
                       >
-                        {leaveType.icon}
-                      </div>
-                      <span className="font-medium">{leaveType.label}</span>
-                    </button>
-                  ))}
+                        <div
+                          className="bg-muted flex h-9 w-9 shrink-0 items-center justify-center rounded-lg"
+                          aria-hidden="true"
+                        >
+                          <Icon className="text-muted-foreground h-5 w-5" />
+                        </div>
+                        <span className="text-foreground text-sm font-medium">
+                          {lt.label}
+                        </span>
+                      </button>
+                    );
+                  })}
                 </div>
               </div>
 
-              {/* Reason Field */}
-              <div className="space-y-3">
-                <Label htmlFor="leave-reason" className="text-sm font-semibold">
-                  เหตุผล (ถ้ามี)
+              {/* ── เหตุผล ── */}
+              <div id="leave-reason-field" className="space-y-1.5">
+                <Label htmlFor="leave-reason" className="text-sm font-medium">
+                  เหตุผล{" "}
+                  <span className="text-muted-foreground font-normal">
+                    (ถ้ามี)
+                  </span>
                 </Label>
-                <input
+                <textarea
                   id="leave-reason"
-                  type="text"
+                  name="leave-reason"
                   value={reason}
                   onChange={(e) => setReason(e.target.value)}
-                  className="w-full rounded-lg border bg-background px-3 py-2 text-foreground transition focus:outline-none focus:ring-2 focus:ring-primary"
-                  placeholder="ระบุเหตุผล (ถ้ามี)"
+                  rows={3}
+                  placeholder="ระบุเหตุผลเพิ่มเติม..."
+                  aria-label="เหตุผลการลา (ไม่บังคับ)"
+                  className="border-input bg-background text-foreground placeholder:text-muted-foreground focus-visible:ring-ring w-full resize-none rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-50"
                 />
               </div>
 
+              {/* ── Submit ── */}
               <Button
+                id="leave-submit"
                 type="submit"
                 disabled={loading}
                 className="w-full"
                 size="lg"
+                aria-busy={loading}
               >
-                <Save className="mr-2 h-4 w-4" />
-                {loading ? "กำลังบันทึก..." : "บันทึกวันลา"}
+                {loading ? (
+                  <>
+                    <Loader2
+                      className="mr-2 h-4 w-4 animate-spin"
+                      aria-hidden="true"
+                    />
+                    กำลังบันทึก...
+                  </>
+                ) : (
+                  <>
+                    <CalendarIcon className="mr-2 h-4 w-4" aria-hidden="true" />
+                    บันทึกวันลา
+                  </>
+                )}
               </Button>
             </form>
           </CardContent>
         </Card>
 
-        {/* Info Section */}
-        <div className="space-y-2 rounded-lg border border-blue-500/50 bg-blue-500/10 p-6">
-          <h3 className="font-semibold text-blue-700 dark:text-blue-400">
-            ℹ️ ข้อมูลสำคัญ
-          </h3>
-          <p className="text-sm text-blue-700/80 dark:text-blue-400/80">
-            เมื่อบันทึกวันลา ระบบจะสร้างบันทึกการทำงานอัตโนมัติให้
-            โดยเวลาเข้างาน 08:00 น. และเวลาออกงาน 17:00 น. (เวลาประเทศไทย)
+        {/* ── Info Box ── */}
+        <div
+          id="leave-info"
+          role="note"
+          className="flex gap-3 rounded-xl border border-blue-200 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-950/30"
+        >
+          <Info
+            className="mt-0.5 h-4 w-4 shrink-0 text-blue-500 dark:text-blue-400"
+            aria-hidden="true"
+          />
+          <p
+            id="leave-info-text"
+            className="text-sm leading-relaxed text-blue-700 dark:text-blue-300"
+          >
+            เมื่อบันทึกวันลา ระบบจะสร้างบันทึกการทำงานให้อัตโนมัติ โดยกำหนด
+            เข้างาน 08:00 น. — ออกงาน 17:00 น. (เวลาประเทศไทย)
           </p>
         </div>
+
+        {/* ── Leave History ── */}
+        <Card id="leave-history" className="shadow-sm">
+          <CardHeader className="pb-3">
+            <div className="flex items-center justify-between">
+              <CardTitle
+                id="leave-history-title"
+                className="flex items-center gap-2 text-base"
+              >
+                <ClipboardList
+                  className="text-primary h-4 w-4"
+                  aria-hidden="true"
+                />
+                ประวัติการลา
+              </CardTitle>
+
+              {/* Month navigation */}
+              <nav
+                id="leave-history-nav"
+                aria-label="นำทางเดือน"
+                className="flex items-center gap-0.5"
+              >
+                <button
+                  id="leave-history-prev"
+                  type="button"
+                  onClick={() => setHistoryMonth((m) => shiftMonth(m, -1))}
+                  aria-label="เดือนก่อนหน้า"
+                  className="hover:bg-accent focus-visible:ring-ring flex h-7 w-7 items-center justify-center rounded-md transition-colors focus-visible:ring-2 focus-visible:outline-none"
+                >
+                  <ChevronLeft className="h-4 w-4" aria-hidden="true" />
+                </button>
+
+                <span
+                  id="leave-history-month"
+                  aria-live="polite"
+                  aria-atomic="true"
+                  className="min-w-[112px] text-center text-sm font-medium tabular-nums"
+                >
+                  {getThaiMonthLabel(historyMonth)}
+                </span>
+
+                <button
+                  id="leave-history-next"
+                  type="button"
+                  onClick={() => setHistoryMonth((m) => shiftMonth(m, 1))}
+                  disabled={historyMonth >= currentMonthStr}
+                  aria-label="เดือนถัดไป"
+                  aria-disabled={historyMonth >= currentMonthStr}
+                  className="hover:bg-accent focus-visible:ring-ring flex h-7 w-7 items-center justify-center rounded-md transition-colors focus-visible:ring-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-40"
+                >
+                  <ChevronRight className="h-4 w-4" aria-hidden="true" />
+                </button>
+              </nav>
+            </div>
+          </CardHeader>
+
+          <CardContent>
+            {historyLoading ? (
+              <div
+                id="leave-history-loading"
+                role="status"
+                aria-label="กำลังโหลดข้อมูลการลา"
+                className="flex justify-center py-8"
+              >
+                <Loader2
+                  className="text-muted-foreground h-5 w-5 animate-spin"
+                  aria-hidden="true"
+                />
+              </div>
+            ) : leaves.length === 0 ? (
+              <div
+                id="leave-history-empty"
+                className="flex flex-col items-center gap-2 py-8"
+              >
+                <CalendarIcon
+                  className="text-muted-foreground/40 h-8 w-8"
+                  aria-hidden="true"
+                />
+                <p className="text-muted-foreground text-sm">
+                  ไม่มีข้อมูลการลาในเดือนนี้
+                </p>
+              </div>
+            ) : (
+              <ul
+                id="leave-history-list"
+                aria-label="รายการวันลา"
+                className="space-y-2"
+              >
+                {leaves.map((leave) => {
+                  const lt = LEAVE_TYPE_MAP[leave.type];
+                  const Icon = lt?.icon;
+                  return (
+                    <li
+                      key={leave.id}
+                      id={`leave-history-item-${leave.id}`}
+                      className="bg-card hover:bg-accent/30 flex items-center justify-between rounded-xl border px-3 py-2.5 transition-colors"
+                    >
+                      <div className="flex items-center gap-3">
+                        {Icon ? (
+                          <div
+                            className="bg-muted flex h-8 w-8 shrink-0 items-center justify-center rounded-lg"
+                            aria-hidden="true"
+                          >
+                            <Icon className="text-muted-foreground h-4 w-4" />
+                          </div>
+                        ) : null}
+                        <div>
+                          <p className="text-sm font-medium">
+                            {formatThaiShortDate(leave.date)}
+                          </p>
+                          {leave.reason ? (
+                            <p className="text-muted-foreground mt-0.5 text-xs">
+                              {leave.reason}
+                            </p>
+                          ) : null}
+                        </div>
+                      </div>
+
+                      <Badge variant="outline" className="shrink-0 text-xs">
+                        {lt?.label ?? leave.type}
+                      </Badge>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+
+            {/* Summary footer */}
+            {!historyLoading && leaves.length > 0 && (
+              <p
+                id="leave-history-summary"
+                className="text-muted-foreground mt-3 text-right text-xs"
+              >
+                รวม {leaves.length} วัน
+              </p>
+            )}
+          </CardContent>
+        </Card>
       </div>
     </div>
   );

--- a/src/input.css
+++ b/src/input.css
@@ -266,6 +266,12 @@
   --card-bg-orange-hover: #fed7aa; /* Orange-200 */
   --card-bg-red-hover: #fecaca; /* Red-200 */
 
+  /* Card text colors */
+  --card-text-blue: #2563eb;     /* blue-600 */
+  --card-text-green: #059669;    /* emerald-600 */
+  --card-text-purple: #7c3aed;   /* violet-600 */
+  --card-text-red: #e11d48;      /* rose-600 */
+
   --table-divider: #e5e7eb; /* Table row separators */
   --table-header-bg: #f9fafb; /* Table header background */
   --background: oklch(0.9777 0.0041 301.4256);
@@ -345,6 +351,24 @@
   --card-bg-purple: rgba(88, 28, 135, 0.25); /* Purple with opacity */
   --card-bg-orange: rgba(154, 52, 18, 0.25); /* Orange with opacity */
   --card-bg-red: rgba(153, 27, 27, 0.25); /* Red with opacity */
+
+  /* Border colors for dark mode */
+  --card-border-blue: rgba(147, 197, 253, 0.40);   /* blue-300/40 */
+  --card-border-green: rgba(134, 239, 172, 0.40);  /* green-300/40 */
+  --card-border-purple: rgba(192, 132, 252, 0.40); /* purple-300/40 */
+  --card-border-red: rgba(252, 165, 165, 0.40);    /* red-300/40 */
+
+  /* Hover/active backgrounds for dark mode */
+  --card-bg-blue-hover: rgba(30, 58, 138, 0.45);
+  --card-bg-green-hover: rgba(20, 83, 45, 0.45);
+  --card-bg-purple-hover: rgba(88, 28, 135, 0.45);
+  --card-bg-red-hover: rgba(153, 27, 27, 0.45);
+
+  /* Card text colors for dark mode */
+  --card-text-blue: #93c5fd;   /* blue-300 */
+  --card-text-green: #6ee7b7;  /* emerald-300 */
+  --card-text-purple: #c4b5fd; /* violet-300 */
+  --card-text-red: #fda4af;    /* rose-300 */
 
   --table-divider: #374151; /* Table row separators */
   --table-header-bg: #111827; /* Table header background */
@@ -550,6 +574,34 @@
     background-color: var(--card-bg-red-hover);
   }
 
+  /* Card active/static backgrounds (same value as hover, for selected state) */
+  .bg-card-blue-hover {
+    background-color: var(--card-bg-blue-hover);
+  }
+  .bg-card-green-hover {
+    background-color: var(--card-bg-green-hover);
+  }
+  .bg-card-purple-hover {
+    background-color: var(--card-bg-purple-hover);
+  }
+  .bg-card-red-hover {
+    background-color: var(--card-bg-red-hover);
+  }
+
+  /* Card text colors — auto-adapt light/dark via CSS variable */
+  .text-card-blue {
+    color: var(--card-text-blue);
+  }
+  .text-card-green {
+    color: var(--card-text-green);
+  }
+  .text-card-purple {
+    color: var(--card-text-purple);
+  }
+  .text-card-red {
+    color: var(--card-text-red);
+  }
+
   /* Table Utilities */
   .divide-theme-table > * + * {
     border-top-color: var(--table-divider);
@@ -559,9 +611,25 @@
     background-color: var(--table-header-bg);
   }
 
-  /* 🗓️ Calendar Improvements */
+  /* 🗓️ DayPicker v8 legacy */
   .rdp {
     --rdp-cell-size: 40px;
+    font-family: var(--font-noto-sans-thai);
+  }
+
+  /* 🗓️ DayPicker v9 — theme override (light + dark) */
+  .rdp-root {
+    --rdp-accent-color: var(--color-primary);
+    --rdp-accent-background-color: color-mix(
+      in oklab,
+      var(--color-primary) 12%,
+      transparent
+    );
+    --rdp-today-color: var(--color-primary);
+    --rdp-day-height: 38px;
+    --rdp-day-width: 38px;
+    --rdp-day_button-height: 36px;
+    --rdp-day_button-width: 36px;
     font-family: var(--font-noto-sans-thai);
   }
 

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -37,6 +37,7 @@ import { isAdminLineUser } from "@/lib/auth/admin";
 import { syncLineProfileToDatabase } from "@/lib/auth/line-profile-sync";
 import "../input.css";
 import "@/styles/dca-theme.css";
+import "react-day-picker/style.css";
 
 interface RouterContext {
   session: AppSession | null;

--- a/src/routes/leave.tsx
+++ b/src/routes/leave.tsx
@@ -11,7 +11,7 @@ function LeavePage() {
       {/* Pending Approval Modal */}
       <PendingApprovalModal open={needsApproval} />
 
-      <main className="flex h-full min-h-screen w-full flex-col items-center justify-center p-4 transition-colors duration-500 sm:p-6 lg:p-8">
+      <main className="min-h-screen w-full">
         <LeaveForm />
       </main>
     </>


### PR DESCRIPTION
# feat: improve leave form UI with Thai calendar and history

## Summary
- 🎨 **Complete UI redesign** of the leave form with modern, accessible components
- 📅 **Thai Buddhist calendar** integration using react-day-picker/buddhist
- 📜 **Leave history section** with month navigation and Thai date formatting
- 🌓 **Enhanced dark mode** support with proper CSS variable theming
- ♿ **Improved accessibility** with ARIA labels, roles, and keyboard navigation
- ⚡ **Better UX** with loading states, form validation, and auto-refresh

## Testing
- [x] Calendar date selection opens and works correctly
- [x] Thai date formatting displays properly (e.g., "วันพฤหัสบดีที่ 18 เมษายน 2569")
- [x] Leave type buttons show proper active states
- [x] Form submission creates leave records successfully
- [x] Leave history loads and displays for selected month
- [x] Month navigation (prev/next) works in history section
- [x] History auto-refreshes after submitting new leave
- [x] Dark mode styling displays correctly
- [x] Loading states appear during form submission and history fetch
- [x] Responsive design works on mobile devices
- [x] Keyboard navigation works for all interactive elements