### PR TITLE
feat(expenses): expense tracker with LINE bot integration

### DIFF
--- a/src/components/calendar/holiday-manage-modal.tsx
+++ b/src/components/calendar/holiday-manage-modal.tsx
@@ -132,10 +132,11 @@ export function HolidayManageModal({
             <input
               id="holiday-year"
               type="number"
+              inputMode="numeric"
               value={year}
               onChange={(e) => setYear(parseInt(e.target.value))}
               className={cn(
-                "w-full px-3 py-2 border rounded-lg",
+                "w-full px-3 py-2 border rounded-lg [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none",
                 "bg-background dark:bg-gray-800 dark:border-gray-700 dark:text-gray-100",
                 "focus:outline-none focus:ring-2 focus:ring-red-500"
               )}

--- a/src/components/subscriptions/AddMemberModal.tsx
+++ b/src/components/subscriptions/AddMemberModal.tsx
@@ -158,12 +158,13 @@ export const AddMemberModal = ({
             <div className="flex gap-2">
               <input
                 type="number"
+                inputMode="decimal"
                 min="0"
                 step="0.01"
                 value={form.shareAmount}
                 onChange={(e) => setForm((p) => ({ ...p, shareAmount: parseFloat(e.target.value) || 0 }))}
                 required
-                className="flex-1 rounded-xl border border-gray-300 bg-white px-4 py-2.5 text-sm text-gray-900 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+                className="flex-1 rounded-xl border border-gray-300 bg-white px-4 py-2.5 text-sm text-gray-900 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 dark:border-gray-600 dark:bg-gray-800 dark:text-white [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
               />
               {totalPrice > 0 && (
                 <button

--- a/src/components/subscriptions/AddSubscriptionModal.tsx
+++ b/src/components/subscriptions/AddSubscriptionModal.tsx
@@ -215,6 +215,7 @@ export const AddSubscriptionModal = ({
                 </label>
                 <input
                   type="number"
+                  inputMode="decimal"
                   min="0"
                   step="0.01"
                   value={form.totalPrice}
@@ -222,7 +223,7 @@ export const AddSubscriptionModal = ({
                     setForm((p) => ({ ...p, totalPrice: parseFloat(e.target.value) || 0 }))
                   }
                   required
-                  className="w-full rounded-xl border border-gray-300 bg-white px-4 py-2.5 text-sm text-gray-900 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+                  className="w-full rounded-xl border border-gray-300 bg-white px-4 py-2.5 text-sm text-gray-900 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 dark:border-gray-600 dark:bg-gray-800 dark:text-white [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
                 />
               </div>
 
@@ -232,6 +233,7 @@ export const AddSubscriptionModal = ({
                 </label>
                 <input
                   type="number"
+                  inputMode="numeric"
                   min="1"
                   max="31"
                   value={form.billingDay}
@@ -239,7 +241,7 @@ export const AddSubscriptionModal = ({
                     setForm((p) => ({ ...p, billingDay: parseInt(e.target.value) || 1 }))
                   }
                   required
-                  className="w-full rounded-xl border border-gray-300 bg-white px-4 py-2.5 text-sm text-gray-900 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+                  className="w-full rounded-xl border border-gray-300 bg-white px-4 py-2.5 text-sm text-gray-900 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 dark:border-gray-600 dark:bg-gray-800 dark:text-white [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
                 />
               </div>
             </div>

--- a/src/components/subscriptions/EditPaymentModal.tsx
+++ b/src/components/subscriptions/EditPaymentModal.tsx
@@ -111,12 +111,13 @@ export const EditPaymentModal = ({
             </label>
             <input
               type="number"
+              inputMode="decimal"
               min="0"
               step="0.01"
               value={form.amount}
               onChange={(e) => setForm((p) => ({ ...p, amount: parseFloat(e.target.value) || 0 }))}
               required
-              className="w-full rounded-xl border border-gray-300 bg-white px-4 py-2.5 text-sm text-gray-900 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+              className="w-full rounded-xl border border-gray-300 bg-white px-4 py-2.5 text-sm text-gray-900 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 dark:border-gray-600 dark:bg-gray-800 dark:text-white [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
             />
           </div>
 

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -7,12 +7,13 @@ export interface InputProps
   extends React.InputHTMLAttributes<HTMLInputElement> {}
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type, ...props }, ref) => {
+  ({ className, type, inputMode, ...props }, ref) => {
     return (
       <input
         type={type}
+        inputMode={inputMode ?? (type === "number" ? "decimal" : undefined)}
         className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none",
           className,
         )}
         ref={ref}

--- a/src/features/line/commands/handleExpenseCommand.ts
+++ b/src/features/line/commands/handleExpenseCommand.ts
@@ -27,7 +27,8 @@ import {
   getCurrentMonth,
   toTransDate,
 } from "@/features/expenses/helpers";
-import type { ExpenseCategory } from "@/features/expenses/types";
+import type { ExpenseCategory, MonthlySummary, CategorySummary } from "@/features/expenses/types";
+import { flexMessage } from "@/lib/utils/line-message-utils";
 import { env } from "@/env.mjs";
 
 // ─────────────────────────────────────────────
@@ -37,6 +38,155 @@ const getSendMessage = async () => {
   const mod = await import("@/lib/utils/line-utils");
   return mod.sendMessage;
 };
+
+// ─────────────────────────────────────────────
+// Flex Message builder
+// ─────────────────────────────────────────────
+
+function createExpenseSummaryBubble(
+  summary: MonthlySummary,
+  categories: CategorySummary[],
+  transMonth: string,
+  frontendUrl: string,
+): object {
+  const balance = summary.balance;
+  const isPositive = balance >= 0;
+  const headerColor = isPositive ? "#16A34A" : "#D97706";
+  const balanceColor = isPositive ? "#16A34A" : "#EF4444";
+  const balanceSign = isPositive ? "+" : "-";
+
+  const row = (label: string, value: string, valueColor: string) => ({
+    type: "box",
+    layout: "horizontal",
+    spacing: "sm",
+    contents: [
+      { type: "text", text: label, size: "sm", color: "#6B7280", flex: 2 },
+      {
+        type: "text",
+        text: value,
+        size: "sm",
+        color: valueColor,
+        weight: "bold",
+        align: "end",
+        flex: 3,
+      },
+    ],
+  });
+
+  const bodyContents: object[] = [
+    row(`📈 รายรับ`, `+${fmt(summary.totalIncome)} บาท`, "#16A34A"),
+    row(`📉 รายจ่าย`, `-${fmt(summary.totalExpense)} บาท`, "#EF4444"),
+    { type: "separator", margin: "md" },
+    {
+      type: "box",
+      layout: "horizontal",
+      spacing: "sm",
+      margin: "md",
+      contents: [
+        {
+          type: "text",
+          text: "⚖️ คงเหลือ",
+          size: "md",
+          color: "#111827",
+          weight: "bold",
+          flex: 2,
+        },
+        {
+          type: "text",
+          text: `${balanceSign}${fmt(Math.abs(balance))} บาท`,
+          size: "md",
+          color: balanceColor,
+          weight: "bold",
+          align: "end",
+          flex: 3,
+        },
+      ],
+    },
+    {
+      type: "text",
+      text: `📋 ${summary.transactionCount} รายการ`,
+      size: "xs",
+      color: "#9CA3AF",
+      align: "end",
+      margin: "sm",
+    },
+  ];
+
+  const topExpenses = categories.filter((c) => c.type === "EXPENSE").slice(0, 3);
+  if (topExpenses.length > 0) {
+    bodyContents.push(
+      { type: "separator", margin: "md" },
+      {
+        type: "text",
+        text: "🔍 รายจ่ายสูงสุด",
+        size: "sm",
+        color: "#374151",
+        weight: "bold",
+        margin: "md",
+      },
+      ...topExpenses.map((c) =>
+        row(
+          `${c.icon ?? "📦"} ${c.categoryName}`,
+          `${fmt(c.total)} บาท`,
+          "#374151",
+        ),
+      ),
+    );
+  }
+
+  return {
+    type: "bubble",
+    size: "giga",
+    header: {
+      type: "box",
+      layout: "vertical",
+      paddingAll: "20px",
+      backgroundColor: headerColor,
+      contents: [
+        {
+          type: "text",
+          text: "💰 สรุปรายรับรายจ่าย",
+          weight: "bold",
+          size: "xl",
+          color: "#ffffff",
+          align: "center",
+        },
+        {
+          type: "text",
+          text: `📅 ${formatMonthThai(transMonth)}`,
+          size: "sm",
+          color: "#ffffff",
+          align: "center",
+          margin: "sm",
+        },
+      ],
+    },
+    body: {
+      type: "box",
+      layout: "vertical",
+      spacing: "sm",
+      paddingAll: "20px",
+      contents: bodyContents,
+    },
+    footer: {
+      type: "box",
+      layout: "vertical",
+      paddingAll: "12px",
+      contents: [
+        {
+          type: "button",
+          style: "primary",
+          color: headerColor,
+          action: {
+            type: "uri",
+            label: "ดูรายการทั้งหมด",
+            uri: `${frontendUrl}/expenses`,
+          },
+        },
+      ],
+    },
+  };
+}
 
 // ─────────────────────────────────────────────
 // Helpers
@@ -66,59 +216,134 @@ const fmt = (n: number) => formatAmount(Math.abs(n));
 /** แสดง help */
 async function handleHelp(req: unknown) {
   const sendMessage = await getSendMessage();
-  const helpText = {
-    type: "text",
-    text: [
-      "💰 รายรับรายจ่าย — คำสั่งทั้งหมด",
-      "─────────────────────",
-      "🔹 บันทึกรายจ่าย:",
-      "  /จ่าย [จำนวน] [หมวด?]",
-      "  /จ่าย 250 อาหาร",
-      "  /exp 1200 เดินทาง",
-      "  /e 50",
-      "",
-      "🔹 บันทึกรายรับ:",
-      "  /รับ [จำนวน] [หมวด?]",
-      "  /รับ 30000 เงินเดือน",
-      "  /i 5000 โบนัส",
-      "",
-      "🔹 ดูสรุปเดือนนี้:",
-      "  /expense",
-      "  /expense sum",
-      "",
-      "🔹 ดูรายการล่าสุด:",
-      "  /expense list",
-      "",
-      "─────────────────────",
-      "⚡ คำสั่งย่อ:",
-      "  /จ่าย = /exp = /e  → รายจ่าย",
-      "  /รับ  = /i         → รายรับ",
-      "",
-      "📌 /expense help — แสดงคำสั่งนี้",
-      "─────────────────────",
-      "💡 หมวดหมู่จับคู่อัตโนมัติ",
-      "   ไม่ระบุ → ใช้หมวด 'อื่นๆ'",
-    ].join("\n"),
-  };
-  const buttonTemplate = {
-    type: "template",
-    altText: "ดูคำสั่งทั้งหมดบนเว็บไซต์",
-    template: {
-      type: "buttons",
-      text: "คลิกเพื่อดูคำสั่งทั้งหมดพร้อมตัวอย่างบนเว็บไซต์",
-      actions: [
+
+  const section = (emoji: string, title: string, lines: string[]) => ({
+    type: "box",
+    layout: "vertical",
+    spacing: "xs",
+    contents: [
+      {
+        type: "box",
+        layout: "horizontal",
+        spacing: "sm",
+        contents: [
+          { type: "text", text: emoji, size: "sm", flex: 0 },
+          {
+            type: "text",
+            text: title,
+            size: "sm",
+            weight: "bold",
+            color: "#111827",
+            flex: 1,
+          },
+        ],
+      },
+      ...lines.map((line) => ({
+        type: "text",
+        text: line,
+        size: "xs",
+        color: "#6B7280",
+        margin: "xs",
+        wrap: true,
+      })),
+    ],
+  });
+
+  const bubble = {
+    type: "bubble",
+    size: "giga",
+    header: {
+      type: "box",
+      layout: "vertical",
+      paddingAll: "20px",
+      backgroundColor: "#1D4ED8",
+      contents: [
         {
-          type: "uri",
-          label: "ดูรายการคำสั่งทั้งหมด",
-          uri: `${env.FRONTEND_URL}/help`,
+          type: "text",
+          text: "💰 รายรับรายจ่าย",
+          weight: "bold",
+          size: "xl",
+          color: "#ffffff",
+          align: "center",
+        },
+        {
+          type: "text",
+          text: "คำสั่งทั้งหมด",
+          size: "sm",
+          color: "#BFDBFE",
+          align: "center",
+          margin: "xs",
+        },
+      ],
+    },
+    body: {
+      type: "box",
+      layout: "vertical",
+      spacing: "md",
+      paddingAll: "20px",
+      contents: [
+        section("📉", "บันทึกรายจ่าย", [
+          "/จ่าย [จำนวน] [หมวด]",
+          "ตัวอย่าง: /จ่าย 250 อาหาร",
+          "ย่อได้: /exp 1200  หรือ  /e 50",
+        ]),
+        { type: "separator" },
+        section("📈", "บันทึกรายรับ", [
+          "/รับ [จำนวน] [หมวด]",
+          "ตัวอย่าง: /รับ 30000 เงินเดือน",
+          "ย่อได้: /i 5000 โบนัส",
+        ]),
+        { type: "separator" },
+        section("📊", "ดูสรุปเดือนนี้", ["/expense  หรือ  /expense sum"]),
+        { type: "separator" },
+        section("📋", "ดูรายการล่าสุด", ["/expense list"]),
+        { type: "separator" },
+        {
+          type: "box",
+          layout: "vertical",
+          spacing: "xs",
+          contents: [
+            {
+              type: "text",
+              text: "💡 เคล็ดลับ",
+              size: "xs",
+              weight: "bold",
+              color: "#374151",
+            },
+            {
+              type: "text",
+              text: "ไม่ระบุหมวด → ใช้หมวด 'อื่นๆ' อัตโนมัติ",
+              size: "xs",
+              color: "#6B7280",
+              wrap: true,
+            },
+          ],
+        },
+      ],
+    },
+    footer: {
+      type: "box",
+      layout: "vertical",
+      paddingAll: "12px",
+      contents: [
+        {
+          type: "button",
+          style: "primary",
+          color: "#1D4ED8",
+          action: {
+            type: "uri",
+            label: "ดูคำสั่งทั้งหมดบนเว็บไซต์",
+            uri: `${env.FRONTEND_URL}/help`,
+          },
         },
       ],
     },
   };
-  await sendMessage(req as Parameters<typeof sendMessage>[0], [
-    helpText,
-    buttonTemplate,
-  ]);
+
+  await sendMessage(
+    req as Parameters<typeof sendMessage>[0],
+    flexMessage([bubble]),
+  );
 }
 
 /** แสดงสรุปเดือนปัจจุบัน */
@@ -132,36 +357,17 @@ async function handleSummary(req: unknown, userId: string) {
       getCategorySummary(userId, transMonth),
     ]);
 
-    const balance = summary.balance;
-    const balanceSign = balance >= 0 ? "+" : "-";
-    const balanceEmoji = balance >= 0 ? "✅" : "⚠️";
+    const bubble = createExpenseSummaryBubble(
+      summary,
+      categories,
+      transMonth,
+      env.FRONTEND_URL,
+    );
 
-    // top 3 expense categories
-    const topExpense = categories
-      .filter((c) => c.type === "EXPENSE")
-      .slice(0, 3)
-      .map((c) => `  ${c.icon ?? "📦"} ${c.categoryName}: ${fmt(c.total)} บาท`)
-      .join("\n");
-
-    const lines = [
-      `💰 สรุปรายรับรายจ่าย`,
-      `📅 ${formatMonthThai(transMonth)}`,
-      "─────────────────────",
-      `📈 รายรับ:  +${fmt(summary.totalIncome)} บาท`,
-      `📉 รายจ่าย: -${fmt(summary.totalExpense)} บาท`,
-      `${balanceEmoji} คงเหลือ:  ${balanceSign}${fmt(balance)} บาท`,
-      `📋 ${summary.transactionCount} รายการ`,
-    ];
-
-    if (topExpense) {
-      lines.push("─────────────────────", "🔍 รายจ่ายสูงสุด:", topExpense);
-    }
-
-    lines.push("─────────────────────", "🔗 ดูทั้งหมด: /expenses");
-
-    await sendMessage(req as Parameters<typeof sendMessage>[0], [
-      { type: "text", text: lines.join("\n") },
-    ]);
+    await sendMessage(
+      req as Parameters<typeof sendMessage>[0],
+      flexMessage([bubble]),
+    );
   } catch (err) {
     console.error("[Expense Summary] error:", err);
     await sendMessage(req as Parameters<typeof sendMessage>[0], [

--- a/src/features/line/commands/handleHelpCommand.ts
+++ b/src/features/line/commands/handleHelpCommand.ts
@@ -1,50 +1,104 @@
 import { sendMessage } from "../../../lib/utils/line-utils";
-import { replyNotFound } from "@/lib/utils/line-message-utils";
+import { flexMessage, replyNotFound } from "@/lib/utils/line-message-utils";
 import { env } from "@/env.mjs";
 
 export const handleHelpCommand = async (req: any) => {
   try {
-    const helpText = {
-      type: "text",
-      text: [
-        "📋 คำสั่งที่ใช้บ่อย",
-        "─────────────────────",
-        "💰 รายรับรายจ่าย:",
-        "  /จ่าย [จำนวน] [หมวด?]",
-        "  /exp 250 อาหาร",
-        "  /e 50",
-        "  /รับ [จำนวน] [หมวด?]",
-        "  /i 30000 เงินเดือน",
-        "  /expense — ดูสรุปเดือนนี้",
-        "",
-        "💼 ลงเวลางาน:",
-        "  /checkin  /checkout  /status",
-        "",
-        "📊 คริปโต:",
-        "  /bk /bn /cmc [symbol]",
-        "  /chart [symbol]",
-        "",
-        "📌 /dca — Auto DCA",
-        "─────────────────────",
-        "📖 ดูคำสั่งทั้งหมดด้านล่าง",
-      ].join("\n"),
-    };
-    const buttonTemplate = {
-      type: "template",
-      altText: "คำสั่งทั้งหมดและวิธีใช้งาน",
-      template: {
-        type: "buttons",
-        text: "คลิกเพื่อดูคำสั่งทั้งหมดพร้อมตัวอย่าง",
-        actions: [
+    const section = (emoji: string, title: string, lines: string[]) => ({
+      type: "box",
+      layout: "vertical",
+      spacing: "xs",
+      contents: [
+        {
+          type: "box",
+          layout: "horizontal",
+          spacing: "sm",
+          contents: [
+            { type: "text", text: emoji, size: "sm", flex: 0 },
+            {
+              type: "text",
+              text: title,
+              size: "sm",
+              weight: "bold",
+              color: "#111827",
+              flex: 1,
+            },
+          ],
+        },
+        ...lines.map((line) => ({
+          type: "text",
+          text: line,
+          size: "xs",
+          color: "#6B7280",
+          margin: "xs",
+          wrap: true,
+        })),
+      ],
+    });
+
+    const bubble = {
+      type: "bubble",
+      size: "giga",
+      header: {
+        type: "box",
+        layout: "vertical",
+        paddingAll: "20px",
+        backgroundColor: "#1E293B",
+        contents: [
           {
-            type: "uri",
-            label: "ดูรายการคำสั่งทั้งหมด",
-            uri: `${env.FRONTEND_URL}/help`,
+            type: "text",
+            text: "📋 คำสั่งที่ใช้บ่อย",
+            weight: "bold",
+            size: "xl",
+            color: "#ffffff",
+            align: "center",
+          },
+        ],
+      },
+      body: {
+        type: "box",
+        layout: "vertical",
+        spacing: "md",
+        paddingAll: "20px",
+        contents: [
+          section("💰", "รายรับรายจ่าย", [
+            "/จ่าย [จำนวน] [หมวด]  หรือ  /exp  /e",
+            "/รับ [จำนวน] [หมวด]   หรือ  /i",
+            "/expense — ดูสรุปเดือนนี้",
+          ]),
+          { type: "separator" },
+          section("💼", "ลงเวลางาน", [
+            "/checkin  /checkout  /status",
+          ]),
+          { type: "separator" },
+          section("📊", "คริปโต", [
+            "/bk /bn /cmc [symbol]",
+            "/chart [symbol]",
+          ]),
+          { type: "separator" },
+          section("📌", "Auto DCA", ["/dca"]),
+        ],
+      },
+      footer: {
+        type: "box",
+        layout: "vertical",
+        paddingAll: "12px",
+        contents: [
+          {
+            type: "button",
+            style: "primary",
+            color: "#1E293B",
+            action: {
+              type: "uri",
+              label: "ดูคำสั่งทั้งหมด",
+              uri: `${env.FRONTEND_URL}/help`,
+            },
           },
         ],
       },
     };
-    sendMessage(req, [helpText, buttonTemplate]);
+
+    sendMessage(req, flexMessage([bubble]));
   } catch (error) {
     console.error("Error handling help command:", error);
     replyNotFound(req);

--- a/src/features/line/services/line.server.ts
+++ b/src/features/line/services/line.server.ts
@@ -1,9 +1,9 @@
-import { handleLogin } from "../commands/handleLogin";
 import { handleLocation } from "../commands/handleLocation";
 import { handleSticker } from "../commands/handleSticker";
 import { handlePostback } from "../commands/handlePostback";
 import { handleText } from "../commands/handleText";
 import { handleApprovalCheck } from "../commands/handleApprovalCheck";
+import { sendLoadingAnimation } from "@/lib/utils/line-utils";
 
 interface LineApiRequest {
   body?: {
@@ -27,6 +27,21 @@ const handleEvent = async (
 
   if (!Array.isArray(events) || events.length === 0) {
     return res.status(400).json({ error: "No events to process" });
+  }
+
+  // ข้ามข้อความธรรมดาที่ไม่ใช่คำสั่ง (ไม่ขึ้นต้นด้วย /)
+  const hasActionableEvent = events.some((e) => {
+    if (e.type === "postback") return true;
+    if (e.type === "message" && e.message?.type === "sticker") return true;
+    if (e.type === "message" && e.message?.type === "location") return true;
+    if (e.type === "message" && e.message?.type === "text") {
+      return e.message.text?.startsWith("/");
+    }
+    return false;
+  });
+
+  if (!hasActionableEvent) {
+    return res.status(200).json({ message: "ok" });
   }
 
   // 🔒 ตรวจสอบการอนุมัติก่อนทำงาน
@@ -59,9 +74,8 @@ const handleEvent = async (
         switch (event.message.type) {
           case "text":
             if (event.message.text.startsWith("/")) {
+              void sendLoadingAnimation(req, 15);
               await handleText(req, event.message.text);
-            } else {
-              await handleLogin(req, event.message.text);
             }
             break;
           case "sticker":

--- a/src/lib/auth/account-linking.ts
+++ b/src/lib/auth/account-linking.ts
@@ -129,7 +129,10 @@ export const findAccountByLineMessagingApiId = async (
   return await db.account.findFirst({
     where: {
       providerId: "line",
-      lineMessagingApiUserId,
+      OR: [
+        { lineMessagingApiUserId },
+        { accountId: lineMessagingApiUserId },
+      ],
     },
     select: {
       id: true,


### PR DESCRIPTION
## Summary

- Add expense tracker feature (categories, transactions, monthly summary) with full CRUD via web UI
- Integrate expense commands into LINE bot (`/expense`, `/จ่าย`, `/รับ`, `/expense list`, `/expense help`)
- Fix account lookup bug — `/expense sum` returned "ไม่พบบัญชีในระบบ" for LINE Login users because `lineMessagingApiUserId` is never populated; now falls back to `accountId`
- Convert `/expense sum`, `/expense help`, and global `/help` responses to LINE Flex Message bubbles
- Show LINE loading animation before processing slash commands
- Skip approval check and DB queries for non-slash-command messages (plain text ignored)
- Remove number input spin buttons and add correct `inputMode` for mobile keyboards across all forms

## Test plan

- [ ] `/expense sum` works for LINE Login users (no "ไม่พบบัญชีในระบบ")
- [ ] `/expense sum` returns Flex Message with income/expense/balance
- [ ] `/expense help` and `/help` return Flex Message bubbles
- [ ] Loading animation appears before bot responds
- [ ] Plain text messages (non `/`) get no response from bot
- [ ] Number inputs on mobile show numeric keyboard, no spin buttons