### PR TITLE
fix(bitkub): restore price data broken by Bitkub API change

### DIFF
--- a/src/features/crypto/services/exchange.server.ts
+++ b/src/features/crypto/services/exchange.server.ts
@@ -228,14 +228,9 @@ const getCmcList = async (start: number, limit: number) => {
 
 const bitkub = async (currencyName: string): Promise<any> => {
   try {
-    const response = await fetch(
-      `https://api.bitkub.com/api/market/ticker?sym=THB_${currencyName.toUpperCase()}`,
-    );
+    const response = await fetch(`https://api.bitkub.com/api/market/ticker`);
     const data = await response.json();
-    for (const key of Object.keys(data)) {
-      const value = data[key];
-      return value;
-    }
+    return data?.[`THB_${currencyName.toUpperCase()}`];
   } catch (error) {
     console.error(error);
   }


### PR DESCRIPTION
## Summary
- Bitkub's per-symbol ticker endpoint (`?sym=THB_KUB`) now returns `{"error":99,"result":null}` for all symbols
- The old code blindly iterated `Object.keys(response)` and returned the first value — which was `99` (the error code), causing all `parseFloat()` calls downstream to produce `NaN`
- Fix: fetch the full ticker endpoint (no query param) and index into `data["THB_KUB"]` directly — same v1 field shape, no other callers need changes

## Test plan
- [ ] `/bk kub` should show correct last/high/low prices instead of NaN
- [ ] `/bk btc`, `/bk eth`, `/bk usdt` should all resolve correctly from the full ticker map