### PR TITLE
feat(dca): redesign history table with compact layout and expandable rows

### DIFF
--- a/src/features/dca/components/DcaHistoryTable.tsx
+++ b/src/features/dca/components/DcaHistoryTable.tsx
@@ -1,8 +1,11 @@
-import { Bitcoin, RefreshCw } from "lucide-react";
+"use client";
+
+import { Fragment, useState } from "react";
+import { Bitcoin, ChevronDown, ChevronRight, RefreshCw } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import type { DcaOrderListResult } from "@/features/dca/types";
-import { formatCoin, formatDate, formatTHB } from "@/features/dca/utils/format";
+import type { DcaOrder, DcaOrderListResult } from "@/features/dca/types";
+import { formatCoin, formatDateOnly, formatTimeOnly, formatTHB } from "@/features/dca/utils/format";
 import { Pagination } from "./Pagination";
 
 interface DcaHistoryTableProps {
@@ -76,218 +79,199 @@ const CoinIcon = ({ coin, idPrefix }: { coin: string; idPrefix: string }) => {
   );
 };
 
+const OrderDetailRow = ({ order, colSpan }: { order: DcaOrder; colSpan: number }) => (
+  <tr id={`dca-order-detail-${order.id}`} className="bg-muted/5">
+    <td colSpan={colSpan} className="px-4 pb-3 pt-1">
+      <div className="border-l-2 border-primary/20 pl-3 flex flex-wrap gap-x-8 gap-y-1 text-xs">
+        <div className="flex items-center gap-1.5">
+          <span className="text-muted-foreground">Order ID</span>
+          <span className="font-mono text-foreground/70">{order.orderId}</span>
+        </div>
+        {order.note && (
+          <div className="flex items-center gap-1.5">
+            <span className="text-muted-foreground">หมายเหตุ</span>
+            <span className="text-foreground/70">{order.note}</span>
+          </div>
+        )}
+      </div>
+    </td>
+  </tr>
+);
+
 export const DcaHistoryTable = ({
   ordersData,
   error,
   isLoading,
   page,
   onPageChange,
-}: DcaHistoryTableProps) => (
-  <Card id="dca-table-card" className="border-border">
-    <CardHeader id="dca-table-header" className="pb-2">
-      <CardTitle id="dca-table-title" className="text-base font-semibold">
-        รายการคำสั่งซื้อทั้งหมด
-        {ordersData && (
-          <span
-            id="dca-table-total-count"
-            className="text-muted-foreground ml-2 text-sm font-normal"
-          >
-            ({ordersData.total} รายการ)
-          </span>
+}: DcaHistoryTableProps) => {
+  const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set());
+
+  const toggleRow = (id: string) => {
+    setExpandedRows((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  return (
+    <Card id="dca-table-card" className="border-border">
+      <CardHeader id="dca-table-header" className="pb-2">
+        <CardTitle id="dca-table-title" className="text-base font-semibold">
+          รายการคำสั่งซื้อทั้งหมด
+          {ordersData && (
+            <span
+              id="dca-table-total-count"
+              className="text-muted-foreground ml-2 text-sm font-normal"
+            >
+              ({ordersData.total} รายการ)
+            </span>
+          )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent id="dca-table-content" className="p-0">
+        {error && (
+          <div id="dca-table-error" className="px-6 py-4 text-sm text-red-500">
+            {error}
+          </div>
         )}
-      </CardTitle>
-    </CardHeader>
-    <CardContent id="dca-table-content" className="p-0">
-      {error && (
-        <div id="dca-table-error" className="px-6 py-4 text-sm text-red-500">
-          {error}
-        </div>
-      )}
 
-      {isLoading && !ordersData && (
-        <div
-          id="dca-table-loading"
-          className="text-muted-foreground flex items-center justify-center py-16"
-        >
-          <RefreshCw className="mr-2 h-5 w-5 animate-spin" />
-          กำลังโหลด...
-        </div>
-      )}
+        {isLoading && !ordersData && (
+          <div
+            id="dca-table-loading"
+            className="text-muted-foreground flex items-center justify-center py-16"
+          >
+            <RefreshCw className="mr-2 h-5 w-5 animate-spin" />
+            กำลังโหลด...
+          </div>
+        )}
 
-      {ordersData && ordersData.orders.length === 0 && !isLoading && (
-        <div
-          id="dca-table-empty"
-          className="text-muted-foreground flex flex-col items-center justify-center py-16"
-        >
-          <Bitcoin className="mb-3 h-12 w-12 opacity-30" />
-          <p id="dca-table-empty-title" className="text-sm">
-            ยังไม่มีประวัติคำสั่งซื้อ
-          </p>
-          <p id="dca-table-empty-description" className="mt-1 text-xs">
-            กด &ldquo;เพิ่มคำสั่งซื้อ&rdquo; หรือส่ง message จาก Bitkub ผ่าน
-            LINE
-          </p>
-        </div>
-      )}
+        {ordersData && ordersData.orders.length === 0 && !isLoading && (
+          <div
+            id="dca-table-empty"
+            className="text-muted-foreground flex flex-col items-center justify-center py-16"
+          >
+            <Bitcoin className="mb-3 h-12 w-12 opacity-30" />
+            <p id="dca-table-empty-title" className="text-sm">
+              ยังไม่มีประวัติคำสั่งซื้อ
+            </p>
+            <p id="dca-table-empty-description" className="mt-1 text-xs">
+              กด &ldquo;เพิ่มคำสั่งซื้อ&rdquo; หรือส่ง message จาก Bitkub ผ่าน LINE
+            </p>
+          </div>
+        )}
 
-      {ordersData && ordersData.orders.length > 0 && (
-        <div id="dca-table-scroll" className="overflow-x-auto">
-          <table id="dca-orders-table" className="w-full text-sm">
-            <thead id="dca-orders-table-head">
-              <tr id="dca-orders-table-head-row" className="border-border bg-muted/30 border-b">
-                <th id="dca-orders-header-order-id" className="text-muted-foreground px-4 py-3 text-left font-medium whitespace-nowrap">
-                  ID คำสั่ง
-                </th>
-                <th id="dca-orders-header-executed-at" className="text-muted-foreground px-4 py-3 text-left font-medium whitespace-nowrap">
-                  วันที่ทำการ
-                </th>
-                <th id="dca-orders-header-coin" className="text-muted-foreground px-4 py-3 text-left font-medium whitespace-nowrap">
-                  เหรียญ
-                </th>
-                <th id="dca-orders-header-amount" className="text-muted-foreground px-4 py-3 text-right font-medium whitespace-nowrap">
-                  จำนวนเงินต่อรอบ
-                </th>
-                <th id="dca-orders-header-coin-received" className="text-muted-foreground px-4 py-3 text-right font-medium whitespace-nowrap">
-                  จำนวนเหรียญที่ได้รับ
-                </th>
-                <th id="dca-orders-header-price" className="text-muted-foreground px-4 py-3 text-right font-medium whitespace-nowrap">
-                  ราคาต่อเหรียญ
-                </th>
-                <th id="dca-orders-header-round" className="text-muted-foreground px-4 py-3 text-center font-medium whitespace-nowrap">
-                  รอบที่
-                </th>
-                <th id="dca-orders-header-status" className="text-muted-foreground px-4 py-3 text-center font-medium whitespace-nowrap">
-                  สถานะ
-                </th>
-                <th id="dca-orders-header-note" className="text-muted-foreground px-4 py-3 text-left font-medium whitespace-nowrap">
-                  หมายเหตุ
-                </th>
-              </tr>
-            </thead>
-            <tbody id="dca-orders-table-body" className="divide-border divide-y">
-              {ordersData.orders.map((order) => (
-                <tr
-                  id={`dca-order-row-${order.id}`}
-                  key={order.id}
-                  className="hover:bg-muted/20 transition-colors"
-                >
-                  <td
-                    id={`dca-order-${order.id}-order-id`}
-                    className="text-muted-foreground px-4 py-3 font-mono text-xs whitespace-nowrap"
-                  >
-                    {order.orderId}
-                  </td>
-                  <td
-                    id={`dca-order-${order.id}-executed-at`}
-                    className="px-4 py-3 text-xs whitespace-nowrap"
-                  >
-                    {formatDate(order.executedAt)}
-                  </td>
-                  <td
-                    id={`dca-order-${order.id}-coin`}
-                    className="px-4 py-3 whitespace-nowrap"
-                  >
-                    <div
-                      id={`dca-order-${order.id}-coin-group`}
-                      className="flex items-center gap-2"
-                    >
-                      <CoinIcon
-                        coin={order.coin}
-                        idPrefix={`dca-order-${order.id}`}
-                      />
-                      <span
-                        id={`dca-order-${order.id}-coin-label`}
-                        className="font-medium"
-                      >
-                        {order.coin}
-                      </span>
-                    </div>
-                  </td>
-                  <td
-                    id={`dca-order-${order.id}-amount`}
-                    className="px-4 py-3 text-right whitespace-nowrap"
-                  >
-                    <span
-                      id={`dca-order-${order.id}-amount-value`}
-                      className="font-medium"
-                    >
-                      {formatTHB(order.amountTHB)}
-                    </span>
-                    <span
-                      id={`dca-order-${order.id}-amount-unit`}
-                      className="text-muted-foreground ml-1 text-xs"
-                    >
-                      บาท
-                    </span>
-                  </td>
-                  <td
-                    id={`dca-order-${order.id}-coin-received`}
-                    className="px-4 py-3 text-right font-mono text-xs whitespace-nowrap"
-                  >
-                    {formatCoin(order.coinReceived)}{" "}
-                    <span
-                      id={`dca-order-${order.id}-coin-received-unit`}
-                      className="text-muted-foreground"
-                    >
-                      {order.coin}
-                    </span>
-                  </td>
-                  <td
-                    id={`dca-order-${order.id}-price`}
-                    className="px-4 py-3 text-right whitespace-nowrap"
-                  >
-                    <span id={`dca-order-${order.id}-price-value`}>
-                      {formatTHB(order.pricePerCoin)}
-                    </span>
-                    <span
-                      id={`dca-order-${order.id}-price-unit`}
-                      className="text-muted-foreground ml-1 text-xs"
-                    >
-                      บาท
-                    </span>
-                  </td>
-                  <td
-                    id={`dca-order-${order.id}-round`}
-                    className="px-4 py-3 text-center"
-                  >
-                    <span
-                      id={`dca-order-${order.id}-round-value`}
-                      className="font-medium"
-                    >
-                      {order.round}
-                    </span>
-                  </td>
-                  <td
-                    id={`dca-order-${order.id}-status`}
-                    className="px-4 py-3 text-center"
-                  >
-                    <StatusBadge
-                      idPrefix={`dca-order-${order.id}`}
-                      status={order.status}
-                    />
-                  </td>
-                  <td
-                    id={`dca-order-${order.id}-note`}
-                    className="text-muted-foreground max-w-[120px] truncate px-4 py-3"
-                  >
-                    {order.note ?? "-"}
-                  </td>
+        {ordersData && ordersData.orders.length > 0 && (
+          <div id="dca-table-scroll" className="overflow-x-auto">
+            <table id="dca-orders-table" className="w-full text-sm">
+              <thead id="dca-orders-table-head">
+                <tr id="dca-orders-table-head-row" className="border-border bg-muted/30 border-b">
+                  <th className="w-px py-3 pl-3 pr-1" />
+                  <th id="dca-orders-header-executed-at" className="text-muted-foreground w-px px-4 py-3 text-left font-medium whitespace-nowrap">
+                    วันที่ทำการ
+                  </th>
+                  <th id="dca-orders-header-transaction" className="text-muted-foreground px-4 py-3 text-left font-medium whitespace-nowrap">
+                    รายละเอียดการซื้อ
+                  </th>
+                  <th id="dca-orders-header-status" className="text-muted-foreground px-4 py-3 text-center font-medium whitespace-nowrap">
+                    สถานะ
+                  </th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
+              </thead>
+              <tbody id="dca-orders-table-body" className="divide-border divide-y">
+                {ordersData.orders.map((order) => {
+                  const isExpanded = expandedRows.has(order.id);
+                  return (
+                    <Fragment key={order.id}>
+                      <tr
+                        id={`dca-order-row-${order.id}`}
+                        className="hover:bg-muted/20 cursor-pointer transition-colors"
+                        onClick={() => toggleRow(order.id)}
+                      >
+                        <td className="w-px py-3 pl-3 pr-1">
+                          {isExpanded ? (
+                            <ChevronDown className="text-muted-foreground h-4 w-4" />
+                          ) : (
+                            <ChevronRight className="text-muted-foreground h-4 w-4" />
+                          )}
+                        </td>
+                        <td
+                          id={`dca-order-${order.id}-executed-at`}
+                          className="w-px px-4 py-3 whitespace-nowrap"
+                        >
+                          <div className="flex items-center gap-2 text-sm">
+                            <span>{formatDateOnly(order.executedAt)}</span>
+                            <span className="text-muted-foreground">{formatTimeOnly(order.executedAt)}</span>
+                          </div>
+                          <div id={`dca-order-${order.id}-round`} className="mt-1">
+                            <Badge
+                              id={`dca-order-${order.id}-round-badge`}
+                              className="border-border bg-muted text-muted-foreground hover:bg-muted px-1.5 py-0 text-xs font-normal"
+                            >
+                              รอบ {order.round}
+                            </Badge>
+                          </div>
+                        </td>
+                        <td
+                          id={`dca-order-${order.id}-transaction`}
+                          className="px-4 py-3 whitespace-nowrap"
+                        >
+                          <div
+                            id={`dca-order-${order.id}-transaction-primary`}
+                            className="flex items-center gap-2"
+                          >
+                            <CoinIcon coin={order.coin} idPrefix={`dca-order-${order.id}`} />
+                            <span id={`dca-order-${order.id}-amount-value`} className="font-medium">
+                              {formatTHB(order.amountTHB)} บาท
+                            </span>
+                            <span className="text-muted-foreground">→</span>
+                            <span id={`dca-order-${order.id}-coin-received-value`} className="font-mono font-medium">
+                              {formatCoin(order.coinReceived)}{" "}
+                              <span id={`dca-order-${order.id}-coin-received-unit`} className="text-muted-foreground text-xs">
+                                {order.coin}
+                              </span>
+                            </span>
+                          </div>
+                          <div id={`dca-order-${order.id}-price`} className="text-muted-foreground mt-0.5 pl-8 text-xs">
+                            @ {formatTHB(order.pricePerCoin)} บาท/เหรียญ
+                          </div>
+                        </td>
+                        <td
+                          id={`dca-order-${order.id}-status`}
+                          className="px-4 py-3 text-center"
+                        >
+                          <StatusBadge
+                            idPrefix={`dca-order-${order.id}`}
+                            status={order.status}
+                          />
+                        </td>
+                      </tr>
+                      {isExpanded && (
+                        <OrderDetailRow order={order} colSpan={4} />
+                      )}
+                    </Fragment>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
 
-      {ordersData && (
-        <div id="dca-table-pagination" className="border-border border-t px-4">
-          <Pagination
-            currentPage={page}
-            totalPages={ordersData.totalPages}
-            onPageChange={onPageChange}
-          />
-        </div>
-      )}
-    </CardContent>
-  </Card>
-);
+        {ordersData && (
+          <div id="dca-table-pagination" className="border-border border-t px-4">
+            <Pagination
+              currentPage={page}
+              totalPages={ordersData.totalPages}
+              onPageChange={onPageChange}
+            />
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/features/dca/utils/format.ts
+++ b/src/features/dca/utils/format.ts
@@ -12,6 +12,26 @@ export const formatDate = (date: Date | string) => {
   }).format(d);
 };
 
+export const formatDateOnly = (date: Date | string) => {
+  const d = new Date(date);
+  return new Intl.DateTimeFormat("th-TH", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    timeZone: "Asia/Bangkok",
+  }).format(d);
+};
+
+export const formatTimeOnly = (date: Date | string) => {
+  const d = new Date(date);
+  return new Intl.DateTimeFormat("th-TH", {
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZone: "Asia/Bangkok",
+    hour12: false,
+  }).format(d);
+};
+
 export const formatTHB = (n: number) =>
   n.toLocaleString("th-TH", {
     minimumFractionDigits: 2,


### PR DESCRIPTION
## Summary
- Reduce table from 9 columns to 3 by merging coin icon into transaction cell and removing redundant Order ID / Note / Round columns
- Show date + time on same row, round number as badge below
- Combine amount paid, coins received, and price per coin into a single hierarchical cell
- Add accordion expand row per order row that reveals Order ID and note (when present)

## Changes
- `DcaHistoryTable.tsx` — refactored to client component with `useState` for expand/collapse state
- `format.ts` — added `formatDateOnly` and `formatTimeOnly` helpers