### PR TITLE
feat: calendar redesign with day detail panel and design system compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.5.0] - 2026-05-09
+
+### Added
+- **Calendar Day Detail Panel** — คลิกวันที่มีวันหยุด/วันลา แสดง panel รายละเอียด (ชื่อไทย/อังกฤษ, ประเภท, เหตุผล) พร้อมปุ่มแจ้งลาวันนั้น
+- **Calendar Loading Skeleton** — skeleton grid แทน spinner ธรรมดาตอนโหลดข้อมูล
+
+### Changed
+- **Calendar Desktop** — ออกแบบใหม่: ลบ hero-metric cards, รวมสถิติเป็น inline summary, ปรับ grid cell hierarchy, วันหยุด/วันลา badge สวยขึ้น, weekend cells แยกสีอ่อน
+- **Calendar Mobile** — แทนที่ hardcoded `emerald-*`, `sky-*`, `rose-*`, `slate-*` colors ด้วย theme tokens (`primary`, `destructive`, `muted`, `foreground`), ลบ gradient background, ใช้ `bg-background` แทน
+- **Holiday Manage Modal** — ลบ hardcoded `dark:text-gray-*` ทั้งหมด เปลี่ยนเป็น theme tokens
+- **Holiday Import Modal** — ลบ hardcoded `dark:text-gray-*` ทั้งหมด เปลี่ยนเป็น theme tokens
+- **Calendar Components** — เพิ่ม `id` attributes ครบทุก element สำหรับ test targeting
+
+---
+
 ## [1.4.0] - 2026-05-09
 
 ### Added

--- a/src/features/calendar/components/holiday-import.tsx
+++ b/src/features/calendar/components/holiday-import.tsx
@@ -104,10 +104,10 @@ export function HolidayImport({ onImport, onClose }: HolidayImportProps) {
   };
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50 dark:bg-black/70">
-      <Card className="w-full max-w-2xl max-h-[90vh] overflow-auto p-6 dark:bg-gray-900 dark:border-gray-700">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <Card className="bg-card border-border max-h-[90vh] w-full max-w-2xl overflow-auto p-6">
         <div className="flex items-center justify-between mb-4">
-          <h2 className="text-2xl font-bold dark:text-gray-100">นำเข้าวันหยุด</h2>
+          <h2 className="text-foreground text-2xl font-bold">นำเข้าวันหยุด</h2>
           <Button variant="ghost" size="sm" onClick={onClose}>
             <X className="h-4 w-4" />
           </Button>
@@ -115,14 +115,14 @@ export function HolidayImport({ onImport, onClose }: HolidayImportProps) {
 
         <div className="space-y-4">
           {/* File Upload */}
-          <div className="border-2 border-dashed rounded-lg p-6 dark:border-gray-700 dark:bg-gray-800/50">
+          <div className="border-border rounded-lg border-2 border-dashed p-6">
             <label htmlFor="file-upload" className="cursor-pointer">
               <div className="flex flex-col items-center">
-                <Upload className="h-12 w-12 text-muted-foreground mb-2 dark:text-gray-400" />
-                <p className="text-sm text-muted-foreground mb-1 dark:text-gray-400">
+                <Upload className="text-muted-foreground mb-2 h-12 w-12" />
+                <p className="text-muted-foreground mb-1 text-sm">
                   คลิกเพื่อเลือกไฟล์ หรือลากไฟล์มาวางที่นี่
                 </p>
-                <p className="text-xs text-muted-foreground dark:text-gray-500">
+                <p className="text-muted-foreground text-xs">
                   รองรับไฟล์ .json และ .csv
                 </p>
                 <input
@@ -138,19 +138,19 @@ export function HolidayImport({ onImport, onClose }: HolidayImportProps) {
 
           {/* File Info */}
           {file && (
-            <div className="text-sm dark:text-gray-300">
+            <div className="text-foreground text-sm">
               <p className="font-semibold">ไฟล์ที่เลือก:</p>
-              <p className="text-muted-foreground dark:text-gray-400">{file.name}</p>
+              <p className="text-muted-foreground">{file.name}</p>
             </div>
           )}
 
           {/* Preview */}
           {preview.length > 0 && (
             <div>
-              <h3 className="font-semibold mb-2 dark:text-gray-100">ตัวอย่างข้อมูล (แสดง 10 รายการแรก)</h3>
-              <div className="border rounded-lg overflow-auto max-h-64 dark:border-gray-700">
+              <h3 className="text-foreground mb-2 font-semibold">ตัวอย่างข้อมูล (แสดง 10 รายการแรก)</h3>
+              <div className="border-border max-h-64 overflow-auto rounded-lg border">
                 <table className="w-full text-sm">
-                  <thead className="bg-muted dark:bg-gray-800 dark:text-gray-200">
+                  <thead className="bg-muted text-muted-foreground">
                     <tr>
                       <th className="p-2 text-left">วันที่</th>
                       <th className="p-2 text-left">ชื่อ (ไทย)</th>
@@ -159,9 +159,9 @@ export function HolidayImport({ onImport, onClose }: HolidayImportProps) {
                       <th className="p-2 text-left">ประเภท</th>
                     </tr>
                   </thead>
-                  <tbody className="dark:text-gray-300">
+                  <tbody className="text-foreground">
                     {preview.map((item, i) => (
-                      <tr key={i} className="border-t dark:border-gray-700">
+                      <tr key={i} className="border-border border-t">
                         <td className="p-2">{item.date}</td>
                         <td className="p-2">{item.nameThai}</td>
                         <td className="p-2">{item.nameEnglish}</td>
@@ -177,7 +177,7 @@ export function HolidayImport({ onImport, onClose }: HolidayImportProps) {
 
           {/* Error */}
           {error && (
-            <div className="bg-destructive/10 text-destructive p-3 rounded-lg text-sm dark:bg-red-950/30 dark:text-red-400">
+            <div className="bg-destructive/10 text-destructive rounded-lg p-3 text-sm">
               {error}
             </div>
           )}
@@ -196,7 +196,7 @@ export function HolidayImport({ onImport, onClose }: HolidayImportProps) {
           </div>
 
           {/* Template Download */}
-          <div className="text-sm text-muted-foreground dark:text-gray-400">
+          <div className="text-muted-foreground text-sm">
             <p className="mb-2">ไม่มีไฟล์? ดาวน์โหลด Template ได้ที่:</p>
             <div className="flex gap-2">
               <Button variant="outline" size="sm" onClick={() => {

--- a/src/features/calendar/components/holiday-manage-modal.tsx
+++ b/src/features/calendar/components/holiday-manage-modal.tsx
@@ -1,9 +1,9 @@
-import { useState } from "react";
-import { X, Calendar as CalendarIcon, Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { PopoverDatePicker } from "@/components/ui/date-picker";
 import { cn } from "@/lib/utils";
+import { Calendar as CalendarIcon, X } from "lucide-react";
+import { useState } from "react";
 
 interface HolidayManageModalProps {
   isOpen: boolean;
@@ -26,7 +26,7 @@ export function HolidayManageModal({
   selectedDate,
 }: HolidayManageModalProps) {
   const [date, setDate] = useState<Date | undefined>(
-    selectedDate ? new Date(selectedDate) : undefined
+    selectedDate ? new Date(selectedDate) : undefined,
   );
   const [nameEnglish, setNameEnglish] = useState("");
   const [nameThai, setNameThai] = useState("");
@@ -59,8 +59,8 @@ export function HolidayManageModal({
     }
 
     try {
-      await onSubmit({
-        date: date.toISOString().split('T')[0], // Format as YYYY-MM-DD
+      onSubmit({
+        date: date.toISOString().substring(0, 10), // Format as YYYY-MM-DD
         nameEnglish,
         nameThai,
         year,
@@ -84,18 +84,21 @@ export function HolidayManageModal({
 
   return (
     <div
-      className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50 dark:bg-black/70"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
       role="dialog"
       aria-modal="true"
       aria-labelledby="holiday-modal-title"
     >
-      <Card className="w-full max-w-lg max-h-[90vh] overflow-auto p-6 dark:bg-gray-900 dark:border-gray-700">
-        <div className="flex items-center justify-between mb-4">
+      <Card className="bg-card border-border max-h-[90vh] w-full max-w-lg overflow-auto p-6">
+        <div className="mb-4 flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <CalendarIcon className="h-5 w-5 text-red-500" aria-hidden="true" />
+            <CalendarIcon
+              className="text-destructive h-5 w-5"
+              aria-hidden="true"
+            />
             <h2
               id="holiday-modal-title"
-              className="text-xl font-bold dark:text-gray-100"
+              className="text-foreground text-xl font-bold"
             >
               {selectedDate ? "แก้ไขวันหยุด" : "เพิ่มวันหยุดใหม่"}
             </h2>
@@ -125,7 +128,7 @@ export function HolidayManageModal({
           <div>
             <label
               htmlFor="holiday-year"
-              className="block text-sm font-medium mb-1 dark:text-gray-200"
+              className="text-foreground mb-1 block text-sm font-medium"
             >
               ปี ค.ศ. <span className="text-red-500">*</span>
             </label>
@@ -136,9 +139,9 @@ export function HolidayManageModal({
               value={year}
               onChange={(e) => setYear(parseInt(e.target.value))}
               className={cn(
-                "w-full px-3 py-2 border rounded-lg [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none",
-                "bg-background dark:bg-gray-800 dark:border-gray-700 dark:text-gray-100",
-                "focus:outline-none focus:ring-2 focus:ring-red-500"
+                "w-full [appearance:textfield] rounded-lg border px-3 py-2 [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none",
+                "border-input bg-background text-foreground",
+                "focus:ring-ring focus:ring-2 focus:outline-none",
               )}
               min={2000}
               max={2100}
@@ -147,19 +150,17 @@ export function HolidayManageModal({
             />
             <p
               id="holiday-year-description"
-              className="text-xs text-muted-foreground dark:text-gray-400 mt-1"
+              className="text-muted-foreground mt-1 text-xs"
             >
               ปีคริสต์ศักราช (ค.ศ.) - ถูกตั้งค่าจากวันที่โดยอัตโนมัติ
             </p>
           </div>
 
           {/* Buddhist Year Display (Read-only) */}
-          <div className="bg-muted/50 p-3 rounded-lg dark:bg-gray-800">
+          <div className="bg-muted/50 rounded-lg p-3">
             <div className="flex items-center justify-between">
-              <span className="text-sm text-muted-foreground dark:text-gray-400">
-                ปี พ.ศ.
-              </span>
-              <span className="text-lg font-bold dark:text-gray-100">
+              <span className="text-muted-foreground text-sm">ปี พ.ศ.</span>
+              <span className="text-foreground text-lg font-bold">
                 {year + 543}
               </span>
             </div>
@@ -169,7 +170,7 @@ export function HolidayManageModal({
           <div>
             <label
               htmlFor="holiday-name-thai"
-              className="block text-sm font-medium mb-1 dark:text-gray-200"
+              className="text-foreground mb-1 block text-sm font-medium"
             >
               ชื่อวันหยุด (ไทย) <span className="text-red-500">*</span>
             </label>
@@ -180,16 +181,16 @@ export function HolidayManageModal({
               onChange={(e) => setNameThai(e.target.value)}
               placeholder="เช่น: วันขึ้นปีใหม่"
               className={cn(
-                "w-full px-3 py-2 border rounded-lg",
-                "bg-background dark:bg-gray-800 dark:border-gray-700 dark:text-gray-100",
-                "focus:outline-none focus:ring-2 focus:ring-red-500"
+                "w-full rounded-lg border px-3 py-2",
+                "border-input bg-background text-foreground",
+                "focus:ring-ring focus:ring-2 focus:outline-none",
               )}
               required
               aria-describedby="holiday-name-thai-description"
             />
             <p
               id="holiday-name-thai-description"
-              className="text-xs text-muted-foreground dark:text-gray-400 mt-1"
+              className="text-muted-foreground mt-1 text-xs"
             >
               ชื่อวันหยุดภาษาไทย
             </p>
@@ -199,7 +200,7 @@ export function HolidayManageModal({
           <div>
             <label
               htmlFor="holiday-name-english"
-              className="block text-sm font-medium mb-1 dark:text-gray-200"
+              className="text-foreground mb-1 block text-sm font-medium"
             >
               ชื่อวันหยุด (อังกฤษ) <span className="text-red-500">*</span>
             </label>
@@ -210,16 +211,16 @@ export function HolidayManageModal({
               onChange={(e) => setNameEnglish(e.target.value)}
               placeholder="E.g.: New Year's Day"
               className={cn(
-                "w-full px-3 py-2 border rounded-lg",
-                "bg-background dark:bg-gray-800 dark:border-gray-700 dark:text-gray-100",
-                "focus:outline-none focus:ring-2 focus:ring-red-500"
+                "w-full rounded-lg border px-3 py-2",
+                "border-input bg-background text-foreground",
+                "focus:ring-ring focus:ring-2 focus:outline-none",
               )}
               required
               aria-describedby="holiday-name-english-description"
             />
             <p
               id="holiday-name-english-description"
-              className="text-xs text-muted-foreground dark:text-gray-400 mt-1"
+              className="text-muted-foreground mt-1 text-xs"
             >
               ชื่อวันหยุดภาษาอังกฤษ
             </p>
@@ -229,7 +230,7 @@ export function HolidayManageModal({
           <div>
             <label
               htmlFor="holiday-type"
-              className="block text-sm font-medium mb-1 dark:text-gray-200"
+              className="text-foreground mb-1 block text-sm font-medium"
             >
               ประเภท <span className="text-red-500">*</span>
             </label>
@@ -238,21 +239,21 @@ export function HolidayManageModal({
               value={type}
               onChange={(e) => setType(e.target.value)}
               className={cn(
-                "w-full px-3 py-2 border rounded-lg",
-                "bg-background dark:bg-gray-800 dark:border-gray-700 dark:text-gray-100",
-                "focus:outline-none focus:ring-2 focus:ring-red-500"
+                "w-full rounded-lg border px-3 py-2",
+                "border-input bg-background text-foreground",
+                "focus:ring-ring focus:ring-2 focus:outline-none",
               )}
               required
               aria-describedby="holiday-type-description"
             >
-              <option value="national">วันหยุดราชการ (National)</option>
-              <option value="royal">วันหยุดเกี่ยวกับราชวงศ์ (Royal)</option>
-              <option value="religious">วันหยุดศาสนาจาร (Religious)</option>
-              <option value="special">วันหยุดพิเศษ (Special)</option>
+              <option value="national">วันหยุดราชการ</option>
+              <option value="royal">วันหยุดเกี่ยวกับราชวงศ์</option>
+              <option value="religious">วันหยุดศาสนาจาร</option>
+              <option value="special">วันหยุดพิเศษ</option>
             </select>
             <p
               id="holiday-type-description"
-              className="text-xs text-muted-foreground dark:text-gray-400 mt-1"
+              className="text-muted-foreground mt-1 text-xs"
             >
               เลือกประเภทของวันหยุด
             </p>
@@ -262,7 +263,7 @@ export function HolidayManageModal({
           <div>
             <label
               htmlFor="holiday-description"
-              className="block text-sm font-medium mb-1 dark:text-gray-200"
+              className="text-foreground mb-1 block text-sm font-medium"
             >
               รายละเอียด (ถ้ามี)
             </label>
@@ -272,16 +273,16 @@ export function HolidayManageModal({
               onChange={(e) => setDescription(e.target.value)}
               placeholder="ระบุรายละเอียดเพิ่มเติม..."
               className={cn(
-                "w-full px-3 py-2 border rounded-lg min-h-20",
-                "bg-background dark:bg-gray-800 dark:border-gray-700 dark:text-gray-100",
-                "focus:outline-none focus:ring-2 focus:ring-red-500",
-                "resize-none"
+                "min-h-20 w-full rounded-lg border px-3 py-2",
+                "border-input bg-background text-foreground",
+                "focus:ring-ring focus:ring-2 focus:outline-none",
+                "resize-none",
               )}
               aria-describedby="holiday-description-description"
             />
             <p
               id="holiday-description-description"
-              className="text-xs text-muted-foreground dark:text-gray-400 mt-1"
+              className="text-muted-foreground mt-1 text-xs"
             >
               ระบุรายละเอียดเพิ่มเติม (ไม่บังคับ)
             </p>
@@ -292,14 +293,14 @@ export function HolidayManageModal({
             <div
               role="alert"
               aria-live="assertive"
-              className="bg-destructive/10 text-destructive p-3 rounded-lg text-sm dark:bg-red-950/30 dark:text-red-400"
+              className="bg-destructive/10 text-destructive rounded-lg p-3 text-sm"
             >
               {error}
             </div>
           )}
 
           {/* Actions */}
-          <div className="flex gap-2 justify-end pt-2">
+          <div className="flex justify-end gap-2 pt-2">
             <Button
               type="button"
               variant="outline"
@@ -312,7 +313,7 @@ export function HolidayManageModal({
             <Button
               type="submit"
               disabled={loading}
-              className="bg-red-600 hover:bg-red-700"
+              className="bg-destructive hover:bg-destructive/90 text-destructive-foreground"
               aria-label={loading ? "กำลังบันทึก..." : "บันทึกวันหยุด"}
             >
               {loading ? "กำลังบันทึก..." : "บันทึก"}
@@ -321,7 +322,7 @@ export function HolidayManageModal({
 
           {/* Help Text */}
           <div
-            className="text-xs text-muted-foreground dark:text-gray-400 space-y-1"
+            className="text-muted-foreground space-y-1 text-xs"
             role="note"
             aria-label="คำแนะนำ"
           >

--- a/src/features/calendar/pages/CalendarPage.tsx
+++ b/src/features/calendar/pages/CalendarPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import {
   format,
   addMonths,
@@ -9,18 +9,21 @@ import {
   isSameDay,
   getYear,
   getMonth,
+  isWeekend,
 } from "date-fns";
 import { th } from "date-fns/locale";
 import {
   ChevronLeft,
   ChevronRight,
-  Calendar as CalendarIcon,
   Upload,
   Plus,
   CalendarPlus,
+  X,
+  Star,
+  Clock,
+  FileText,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 import { HolidayImport } from "@/features/calendar/components/holiday-import";
 import { LeaveRequestModal } from "@/features/calendar/components/leave-request-modal";
@@ -43,6 +46,235 @@ interface Leave {
   reason?: string;
 }
 
+const WEEKDAYS = ["อา", "จ", "อ", "พ", "พฤ", "ศ", "ส"] as const;
+
+function DayDetailPanel({
+  date,
+  holiday,
+  leave,
+  onClose,
+  onRequestLeave,
+}: {
+  date: Date;
+  holiday: Holiday | undefined;
+  leave: Leave | undefined;
+  onClose: () => void;
+  onRequestLeave: () => void;
+}) {
+  const dayOfWeek = format(date, "EEEE", { locale: th });
+  const fullDate = format(date, "d MMMM yyyy", { locale: th });
+  const dateStr = format(date, "yyyy-MM-dd");
+  const hasAny = holiday || leave;
+
+  const renderLeaveType = (type: string) => {
+    if (type === "personal") return "ลากิจ";
+    if (type === "sick") return "ลาป่วย";
+    if (type === "vacation") return "ลาพักผ่อน";
+    return type;
+  };
+
+  return (
+    <div
+      id={`day-detail-overlay-${dateStr}`}
+      className="fixed inset-0 z-40 flex items-center justify-center bg-black/30 p-4"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label={`รายละเอียดวันที่ ${fullDate}`}
+    >
+      <div
+        id={`day-detail-panel-${dateStr}`}
+        className="border-border bg-card w-full max-w-sm overflow-hidden rounded-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div
+          id={`day-detail-header-${dateStr}`}
+          className="flex items-start justify-between gap-3 px-5 pt-5 pb-4"
+        >
+          <div>
+            <p
+              id={`day-detail-day-number-${dateStr}`}
+              className="text-foreground text-3xl leading-none font-black"
+            >
+              {format(date, "d")}
+            </p>
+            <p
+              id={`day-detail-day-name-${dateStr}`}
+              className="text-muted-foreground mt-1 text-sm font-medium"
+            >
+              {dayOfWeek}
+            </p>
+            <p
+              id={`day-detail-full-date-${dateStr}`}
+              className="text-muted-foreground text-xs"
+            >
+              {format(date, "MMMM yyyy", { locale: th })}
+            </p>
+          </div>
+          <Button
+            id={`day-detail-close-${dateStr}`}
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8 shrink-0"
+            onClick={onClose}
+            aria-label="ปิด"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+
+        <div
+          id={`day-detail-content-${dateStr}`}
+          className="border-border border-t px-5 py-4"
+        >
+          {hasAny ? (
+            <div className="space-y-3">
+              {holiday && (
+                <div
+                  id={`day-detail-holiday-${dateStr}`}
+                  className="space-y-1.5"
+                >
+                  <div className="flex items-center gap-2">
+                    <span className="bg-destructive text-destructive-foreground flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[10px]">
+                      <Star className="h-3 w-3" />
+                    </span>
+                    <span
+                      id={`day-detail-holiday-label-${dateStr}`}
+                      className="text-muted-foreground text-[10px] font-semibold tracking-wider uppercase"
+                    >
+                      วันหยุดราชการ
+                    </span>
+                  </div>
+                  <div className="pl-7">
+                    <p
+                      id={`day-detail-holiday-name-th-${dateStr}`}
+                      className="text-foreground text-sm font-bold"
+                    >
+                      {holiday.nameThai}
+                    </p>
+                    <p
+                      id={`day-detail-holiday-name-en-${dateStr}`}
+                      className="text-muted-foreground text-xs"
+                    >
+                      {holiday.nameEnglish}
+                    </p>
+                    {holiday.description && (
+                      <p
+                        id={`day-detail-holiday-desc-${dateStr}`}
+                        className="text-muted-foreground mt-1 text-xs"
+                      >
+                        {holiday.description}
+                      </p>
+                    )}
+                    <span
+                      id={`day-detail-holiday-type-${dateStr}`}
+                      className="text-muted-foreground mt-1 inline-block rounded-md bg-muted/60 px-1.5 py-px text-[10px] font-medium"
+                    >
+                      {holiday.type === "national" && "วันหยุดราชการ"}
+                      {holiday.type === "royal" && "วันหยุดเกี่ยวกับราชวงศ์"}
+                      {holiday.type === "religious" && "วันหยุดศาสนาจาร"}
+                      {holiday.type === "special" && "วันหยุดพิเศษ"}
+                      {!["national", "royal", "religious", "special"].includes(holiday.type) && holiday.type}
+                    </span>
+                  </div>
+                </div>
+              )}
+
+              {leave && (
+                <div
+                  id={`day-detail-leave-${dateStr}`}
+                  className="space-y-1.5"
+                >
+                  <div className="flex items-center gap-2">
+                    <span className="border-primary flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-2">
+                      <Clock className="text-primary h-2.5 w-2.5" />
+                    </span>
+                    <span
+                      id={`day-detail-leave-label-${dateStr}`}
+                      className="text-muted-foreground text-[10px] font-semibold tracking-wider uppercase"
+                    >
+                      วันลางาน
+                    </span>
+                  </div>
+                  <div className="pl-7">
+                    <p
+                      id={`day-detail-leave-type-${dateStr}`}
+                      className="text-foreground text-sm font-bold"
+                    >
+                      {renderLeaveType(leave.type)}
+                    </p>
+                    {leave.reason && (
+                      <div
+                        id={`day-detail-leave-reason-${dateStr}`}
+                        className="mt-1 flex items-start gap-1.5"
+                      >
+                        <FileText className="text-muted-foreground mt-0.5 h-3 w-3 shrink-0" />
+                        <p className="text-muted-foreground text-xs">
+                          {leave.reason}
+                        </p>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
+          ) : (
+            <p
+              id={`day-detail-empty-${dateStr}`}
+              className="text-muted-foreground text-sm"
+            >
+              ไม่มีกิจกรรมในวันนี้
+            </p>
+          )}
+        </div>
+
+        <div
+          id={`day-detail-actions-${dateStr}`}
+          className="border-border border-t px-5 py-3"
+        >
+          <Button
+            id={`day-detail-request-leave-${dateStr}`}
+            size="sm"
+            className="w-full"
+            onClick={onRequestLeave}
+          >
+            <Plus className="mr-1.5 h-3.5 w-3.5" />
+            แจ้งลาวันนี้
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SkeletonGrid() {
+  return (
+    <div id="calendar-skeleton" className="flex flex-col">
+      <div className="border-border grid grid-cols-7 border-b">
+        {WEEKDAYS.map((d) => (
+          <div
+            key={d}
+            className="text-muted-foreground px-3 py-3 text-center text-xs font-semibold tracking-widest uppercase"
+          >
+            {d}
+          </div>
+        ))}
+      </div>
+      <div className="grid grid-cols-7">
+        {Array.from({ length: 35 }).map((_, i) => (
+          <div
+            key={i}
+            className="border-border flex h-28 flex-col gap-2 border-b p-2 lg:h-32"
+          >
+            <div className="bg-muted h-5 w-5 animate-pulse rounded-md" />
+            <div className="bg-muted h-4 w-3/4 animate-pulse rounded" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 export function CalendarPage() {
   const [currentDate, setCurrentDate] = useState(new Date());
   const [holidays, setHolidays] = useState<Holiday[]>([]);
@@ -52,6 +284,7 @@ export function CalendarPage() {
   const [showImportModal, setShowImportModal] = useState(false);
   const [showLeaveModal, setShowLeaveModal] = useState(false);
   const [showHolidayModal, setShowHolidayModal] = useState(false);
+  const [showDayDetail, setShowDayDetail] = useState(false);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -77,8 +310,7 @@ export function CalendarPage() {
             setLeaves(leavesData.leaves);
           }
         }
-      } catch (error) {
-        // Error fetching calendar data
+      } catch {
       } finally {
         setLoading(false);
       }
@@ -93,11 +325,10 @@ export function CalendarPage() {
     );
   };
 
-  const getDaysInMonth = () => {
-    const start = startOfMonth(currentDate);
-    const end = endOfMonth(currentDate);
-    return eachDayOfInterval({ start, end });
-  };
+  const days = eachDayOfInterval({
+    start: startOfMonth(currentDate),
+    end: endOfMonth(currentDate),
+  });
 
   const getHolidayForDate = (date: Date) => {
     const dateStr = format(date, "yyyy-MM-dd");
@@ -110,15 +341,14 @@ export function CalendarPage() {
   };
 
   const buddhistYear = getYear(currentDate) + 543;
-  const days = getDaysInMonth();
   const firstDayOfWeek = days[0]?.getDay() ?? 0;
   const calendarRowCount = Math.ceil((firstDayOfWeek + days.length) / 7);
-  const trailingCellCount = calendarRowCount * 7 - firstDayOfWeek - days.length;
+  const trailingCellCount =
+    calendarRowCount * 7 - firstDayOfWeek - days.length;
   const holidayCount = days.filter((date) => getHolidayForDate(date)).length;
   const leaveCount = days.filter((date) => getLeaveForDate(date)).length;
   const workingDayCount = days.length - holidayCount - leaveCount;
 
-  const weekDays = ["อา", "จ", "อ", "พ", "พฤ", "ศ", "ส"];
   const selectedMonth = getMonth(currentDate);
   const selectedYear = getYear(currentDate);
   const monthOptions = Array.from({ length: 12 }, (_, month) => ({
@@ -146,6 +376,31 @@ export function CalendarPage() {
     });
   };
 
+  const refreshLeaves = async () => {
+    const year = getYear(currentDate);
+    const month = getMonth(currentDate) + 1;
+    const leavesRes = await fetch(
+      `/api/leave?month=${year}-${month.toString().padStart(2, "0")}`,
+    );
+    if (leavesRes.ok) {
+      const leavesData = await leavesRes.json();
+      if (leavesData.success) {
+        setLeaves(leavesData.leaves);
+      }
+    }
+  };
+
+  const refreshHolidays = async () => {
+    const year = getYear(currentDate);
+    const holidaysRes = await fetch(`/api/holidays?year=${year}`);
+    if (holidaysRes.ok) {
+      const holidaysData = await holidaysRes.json();
+      if (holidaysData.success) {
+        setHolidays(holidaysData.holidays);
+      }
+    }
+  };
+
   const handleLeaveRequest = async (data: {
     date: string;
     type: string;
@@ -161,27 +416,18 @@ export function CalendarPage() {
       const result = await response.json();
 
       if (result.success) {
-        const year = getYear(currentDate);
-        const month = getMonth(currentDate) + 1;
-        const leavesRes = await fetch(
-          `/api/leave?month=${year}-${month.toString().padStart(2, "0")}`,
-        );
-        if (leavesRes.ok) {
-          const leavesData = await leavesRes.json();
-          if (leavesData.success) {
-            setLeaves(leavesData.leaves);
-          }
-        }
-        alert("✅ แจ้งลาสำเร็จ!");
+        await refreshLeaves();
+        alert("แจ้งลาสำเร็จ!");
       } else {
-        alert(`❌ ${result.message}`);
+        alert(result.message);
       }
-    } catch (err: any) {
-      alert(`❌ เกิดข้อผิดพลาด: ${err.message}`);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "เกิดข้อผิดพลาด";
+      alert(message);
     }
   };
 
-  const handleHolidayAdd = async (data: any) => {
+  const handleHolidayAdd = async (data: Omit<Holiday, "id">) => {
     try {
       const response = await fetch("/api/holidays", {
         method: "POST",
@@ -192,120 +438,121 @@ export function CalendarPage() {
       const result = await response.json();
 
       if (result.success) {
-        const year = getYear(currentDate);
-        const holidaysRes = await fetch(`/api/holidays?year=${year}`);
-        if (holidaysRes.ok) {
-          const holidaysData = await holidaysRes.json();
-          if (holidaysData.success) {
-            setHolidays(holidaysData.holidays);
-          }
-        }
-        alert("✅ เพิ่มวันหยุดสำเร็จ!");
+        await refreshHolidays();
+        alert("เพิ่มวันหยุดสำเร็จ!");
       } else {
-        alert(`❌ ${result.message}`);
+        alert(result.message);
       }
-    } catch (err: any) {
-      alert(`❌ เกิดข้อผิดพลาด: ${err.message}`);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "เกิดข้อผิดพลาด";
+      alert(message);
     }
   };
 
-  const handleDayClick = (date: Date) => {
+  const handleDayClick = useCallback((date: Date) => {
     setSelectedDate(date);
-    setShowLeaveModal(true);
+    const dateStr = format(date, "yyyy-MM-dd");
+    const hasHoliday = holidays.some((h) => h.date === dateStr);
+    const hasLeave = leaves.some((l) => l.date === dateStr);
+    if (hasHoliday || hasLeave) {
+      setShowDayDetail(true);
+    } else {
+      setShowLeaveModal(true);
+    }
+  }, [holidays, leaves]);
+
+  const renderLeaveType = (type: string) => {
+    if (type === "personal") return "ลากิจ";
+    if (type === "sick") return "ลาป่วย";
+    if (type === "vacation") return "ลาพักผ่อน";
+    return type;
   };
 
   return (
-    <div
-      id="calendar-page"
-      className="bg-background text-foreground h-[calc(100svh-3.5rem)] overflow-hidden sm:h-auto sm:min-h-screen sm:overflow-visible"
-    >
-      <main
+    <div id="calendar-page" className="min-h-screen bg-background">
+      <div
         id="calendar-main"
-        className="mx-auto flex h-full w-full max-w-7xl flex-col overflow-hidden px-2 py-2 sm:block sm:h-auto sm:min-h-screen sm:overflow-visible sm:px-5 sm:py-5 lg:px-6 lg:py-8"
+        className="mx-auto w-full max-w-7xl px-4 py-6 sm:px-6 lg:px-8 lg:py-10"
       >
-        <section
-          id="calendar-hero"
-          className="mb-2 grid gap-3 sm:mb-5 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end"
-        >
+        <header id="calendar-hero" className="mb-6 flex items-end justify-between gap-6">
           <div id="calendar-heading">
             <p
               id="calendar-eyebrow"
-              className="text-primary mb-1 text-[10px] font-semibold tracking-[0.18em] uppercase sm:mb-2 sm:text-xs"
+              className="text-muted-foreground mb-1.5 text-[11px] font-semibold tracking-[0.18em] uppercase"
             >
-              Team Calendar
+              ปฏิทินทีม
             </p>
             <h1
               id="calendar-title"
-              className="text-3xl leading-none font-black tracking-tight sm:text-6xl lg:text-7xl"
+              className="text-foreground text-4xl leading-none font-black tracking-tight sm:text-5xl lg:text-6xl"
             >
               {format(currentDate, "MMMM", { locale: th })}
             </h1>
-            <p
+            <div
               id="calendar-subtitle"
-              className="text-muted-foreground mt-1 text-xs font-medium sm:mt-3 sm:text-base"
+              className="text-muted-foreground mt-2 flex items-center gap-3 text-sm font-medium"
             >
-              {format(currentDate, "yyyy", { locale: th })} · พ.ศ.{" "}
-              {buddhistYear}
-            </p>
-          </div>
-
-          <div
-            id="calendar-summary-cards"
-            className="hidden grid-cols-3 gap-2 sm:grid sm:w-auto sm:min-w-[360px]"
-          >
-            <Card
-              id="calendar-summary-holidays"
-              className="border-border bg-card rounded-lg p-3 shadow-none"
-            >
-              <p className="text-muted-foreground text-xs font-medium">
-                วันหยุด
-              </p>
-              <p className="text-destructive mt-1 text-2xl font-black">
-                {holidayCount}
-              </p>
-            </Card>
-            <Card
-              id="calendar-summary-leaves"
-              className="border-border bg-card rounded-lg p-3 shadow-none"
-            >
-              <p className="text-muted-foreground text-xs font-medium">วันลา</p>
-              <p className="text-primary mt-1 text-2xl font-black">
+              <span id="calendar-year-info">
+                {format(currentDate, "yyyy")} · พ.ศ. {buddhistYear}
+              </span>
+              <span className="text-border">|</span>
+              <span id="calendar-summary-text">
+                วันทำงาน {workingDayCount} · วันหยุด {holidayCount} · วันลา{" "}
                 {leaveCount}
-              </p>
-            </Card>
-            <Card
-              id="calendar-summary-workdays"
-              className="border-border bg-card rounded-lg p-3 shadow-none"
-            >
-              <p className="text-muted-foreground text-xs font-medium">
-                วันทำงาน
-              </p>
-              <p className="text-foreground mt-1 text-2xl font-black">
-                {workingDayCount}
-              </p>
-            </Card>
+              </span>
+            </div>
           </div>
-        </section>
 
-        <section
+          <div id="calendar-header-actions" className="hidden items-center gap-2 sm:flex">
+            <Button
+              id="calendar-import-btn"
+              variant="outline"
+              size="sm"
+              onClick={() => setShowImportModal(true)}
+            >
+              <Upload className="mr-1.5 h-3.5 w-3.5" />
+              นำเข้า
+            </Button>
+            <Button
+              id="calendar-add-holiday-btn"
+              variant="outline"
+              size="sm"
+              onClick={() => setShowHolidayModal(true)}
+            >
+              <CalendarPlus className="mr-1.5 h-3.5 w-3.5" />
+              เพิ่มวันหยุด
+            </Button>
+            <Button
+              id="calendar-request-leave-btn"
+              size="sm"
+              onClick={() => setShowLeaveModal(true)}
+            >
+              <Plus className="mr-1.5 h-3.5 w-3.5" />
+              แจ้งลา
+            </Button>
+          </div>
+        </header>
+
+        <nav
           id="calendar-toolbar"
-          className="border-border bg-card mb-2 grid grid-cols-[auto_minmax(0,1fr)_auto] gap-2 rounded-lg border p-2 shadow-sm sm:mb-4 sm:grid-cols-[auto_minmax(0,1fr)_auto_auto] sm:items-center sm:p-3"
+          className="mb-4 flex items-center gap-2"
+          aria-label="เลือกเดือนและปี"
         >
           <Button
             id="calendar-prev-month"
-            onClick={() => navigateMonth("prev")}
             variant="outline"
-            size="sm"
+            size="icon"
+            className="h-9 w-9 shrink-0"
+            onClick={() => navigateMonth("prev")}
+            aria-label="เดือนก่อนหน้า"
           >
-            <ChevronLeft className="mr-2 h-4 w-4" />
-            ก่อน
+            <ChevronLeft className="h-4 w-4" />
           </Button>
 
           <div
             id="calendar-month-picker"
-            className="bg-muted flex min-w-0 items-center justify-center gap-2 rounded-lg px-2 py-2"
+            className="bg-muted flex flex-1 items-center justify-center gap-3 rounded-md px-3 py-2"
           >
-            <CalendarIcon className="text-muted-foreground hidden h-5 w-5 shrink-0 sm:block" />
             <label htmlFor="calendar-month-select" className="sr-only">
               เลือกเดือน
             </label>
@@ -315,7 +562,7 @@ export function CalendarPage() {
               onChange={(event) =>
                 handleMonthChange(Number(event.target.value))
               }
-              className="text-foreground focus-visible:ring-ring min-w-0 flex-1 cursor-pointer appearance-none bg-transparent text-center text-sm font-bold outline-none focus-visible:ring-2 sm:text-lg"
+              className="text-foreground min-w-0 cursor-pointer appearance-none bg-transparent text-center text-sm font-bold outline-none"
               aria-label="เลือกเดือน"
             >
               {monthOptions.map((month) => (
@@ -324,6 +571,7 @@ export function CalendarPage() {
                 </option>
               ))}
             </select>
+            <span className="text-border">/</span>
             <label htmlFor="calendar-year-select" className="sr-only">
               เลือกปี
             </label>
@@ -331,7 +579,7 @@ export function CalendarPage() {
               id="calendar-year-select"
               value={selectedYear}
               onChange={(event) => handleYearChange(Number(event.target.value))}
-              className="text-foreground focus-visible:ring-ring cursor-pointer appearance-none bg-transparent text-center text-sm font-bold outline-none focus-visible:ring-2 sm:text-lg"
+              className="text-foreground cursor-pointer appearance-none bg-transparent text-center text-sm font-bold outline-none"
               aria-label="เลือกปี"
             >
               {yearOptions.map((year) => (
@@ -344,278 +592,199 @@ export function CalendarPage() {
 
           <Button
             id="calendar-next-month"
-            onClick={() => navigateMonth("next")}
             variant="outline"
-            size="sm"
+            size="icon"
+            className="h-9 w-9 shrink-0"
+            onClick={() => navigateMonth("next")}
+            aria-label="เดือนถัดไป"
           >
-            ถัด
-            <ChevronRight className="ml-2 h-4 w-4" />
+            <ChevronRight className="h-4 w-4" />
           </Button>
+        </nav>
 
-          <div
-            id="calendar-action-buttons"
-            className="col-span-3 flex justify-end sm:col-span-1"
-          >
-            <Button
-              id="calendar-request-leave"
-              onClick={() => setShowLeaveModal(true)}
-              variant="default"
-              size="sm"
-              className="bg-primary text-primary-foreground hover:bg-primary/90 h-8 w-full px-3 text-xs sm:h-9 sm:w-auto"
-              aria-label="แจ้งลา"
-            >
-              <Plus className="mr-2 h-4 w-4" />
-              แจ้งลา
-            </Button>
-          </div>
-        </section>
+        <div id="calendar-legend" className="mb-3 flex flex-wrap gap-4 text-xs font-medium">
+          <span id="calendar-legend-holiday" className="flex items-center gap-1.5">
+            <span className="bg-destructive/80 h-2 w-2 rounded-full" />
+            <span className="text-muted-foreground">วันหยุดราชการ</span>
+          </span>
+          <span id="calendar-legend-leave" className="flex items-center gap-1.5">
+            <span className="bg-primary h-2 w-2 rounded-full" />
+            <span className="text-muted-foreground">วันลางาน</span>
+          </span>
+        </div>
 
-        <section
-          id="calendar-legend"
-          className="mb-4 hidden flex-wrap gap-2 text-xs sm:flex sm:text-sm"
-        >
-          <div
-            id="calendar-legend-holiday"
-            className="border-border bg-card flex items-center gap-2 rounded-lg border px-3 py-2"
-          >
-            <div className="bg-destructive h-3 w-3 rounded-full"></div>
-            <span>วันหยุดราชการ</span>
-          </div>
-          <div
-            id="calendar-legend-leave"
-            className="border-border bg-card flex items-center gap-2 rounded-lg border px-3 py-2"
-          >
-            <div className="bg-primary h-3 w-3 rounded-full"></div>
-            <span>วันลางาน</span>
-          </div>
-          <div
-            id="calendar-legend-mixed"
-            className="border-border bg-card flex items-center gap-2 rounded-lg border px-3 py-2"
-          >
-            <div className="bg-accent h-3 w-3 rounded-full"></div>
-            <span>วันหยุด + วันลา</span>
-          </div>
-        </section>
-
-        <Card
+        <div
           id="calendar-grid-card"
-          className="border-border bg-card flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg p-0 shadow-sm sm:block sm:flex-none"
+          className="border-border overflow-hidden rounded-xl border bg-card"
         >
           {loading ? (
-            <div id="calendar-loading" className="py-16 text-center">
-              <div className="border-primary inline-block h-8 w-8 animate-spin rounded-full border-b-2"></div>
-              <p className="text-muted-foreground mt-2 dark:text-gray-400">
-                กำลังโหลดข้อมูล...
-              </p>
+            <div id="calendar-loading" className="p-4">
+              <SkeletonGrid />
             </div>
           ) : (
-            <div
-              id="calendar-grid-wrapper"
-              className="flex min-h-0 flex-1 flex-col"
-            >
+            <div id="calendar-grid-wrapper" className="flex flex-col">
               <div
-                id="calendar-grid-inner"
-                className="flex min-h-0 flex-1 flex-col"
+                id="calendar-weekdays"
+                className="border-border grid shrink-0 grid-cols-7 border-b"
               >
-                <div
-                  id="calendar-weekdays"
-                  className="border-border grid shrink-0 grid-cols-7 border-b"
-                >
-                  {weekDays.map((day) => (
-                    <div
-                      key={day}
-                      id={`calendar-weekday-${day}`}
-                      className="text-muted-foreground px-1 py-2 text-center text-[11px] font-black tracking-[0.08em] uppercase sm:px-3 sm:py-3 sm:text-sm"
+                {WEEKDAYS.map((day) => (
+                  <div
+                    key={day}
+                    id={`calendar-weekday-${day}`}
+                    className={cn(
+                      "text-muted-foreground px-3 py-2.5 text-center text-[11px] font-bold tracking-[0.12em] uppercase",
+                      (day === "อา" || day === "ส") &&
+                        "text-destructive/60",
+                    )}
+                  >
+                    {day}
+                  </div>
+                ))}
+              </div>
+
+              <div
+                id="calendar-days-grid"
+                className="grid grid-cols-7"
+                style={{
+                  gridTemplateRows: `repeat(${calendarRowCount}, minmax(0, 1fr))`,
+                }}
+              >
+                {Array.from({ length: firstDayOfWeek }).map((_, i) => (
+                  <div
+                    key={`empty-${i}`}
+                    id={`calendar-empty-cell-${i}`}
+                    className="border-border/50 bg-muted/20 border-b"
+                  />
+                ))}
+
+                {days.map((date) => {
+                  const holiday = getHolidayForDate(date);
+                  const leave = getLeaveForDate(date);
+                  const isToday = isSameDay(date, new Date());
+                  const isWeekendDay = isWeekend(date);
+                  const hasEvent = holiday || leave;
+                  const dateStr = format(date, "yyyy-MM-dd");
+
+                  return (
+                    <button
+                      key={date.toISOString()}
+                      id={`calendar-day-${dateStr}`}
+                      type="button"
+                      className={cn(
+                        "group relative flex min-h-28 cursor-pointer flex-col border-b p-1.5 text-left transition-colors lg:min-h-32 lg:p-2",
+                        "border-border/50 focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none",
+                        isToday && "bg-primary/[0.04]",
+                        !isToday && !hasEvent && !isWeekendDay && "hover:bg-muted/30",
+                        !isToday && !hasEvent && isWeekendDay && "bg-muted/15 hover:bg-muted/30",
+                      )}
+                      onClick={() => handleDayClick(date)}
+                      aria-label={`${format(date, "d MMMM yyyy", { locale: th })}${holiday ? ` ${holiday.nameThai}` : ""}${leave ? ` วันลา${renderLeaveType(leave.type)}` : ""}`}
                     >
-                      {day}
-                    </div>
-                  ))}
-                </div>
-
-                <div
-                  id="calendar-days-grid"
-                  className="grid min-h-0 flex-1 grid-cols-7 sm:min-h-0"
-                  style={{
-                    gridTemplateRows: `repeat(${calendarRowCount}, minmax(0, 1fr))`,
-                  }}
-                >
-                  {Array.from({ length: firstDayOfWeek }).map((_, i) => (
-                    <div
-                      key={`empty-${i}`}
-                      id={`calendar-empty-cell-${i}`}
-                      className="border-border bg-muted/35 h-full min-h-0 border-b sm:h-32 lg:h-36"
-                    ></div>
-                  ))}
-
-                  {days.map((date) => {
-                    const holiday = getHolidayForDate(date);
-                    const leave = getLeaveForDate(date);
-                    const isToday = isSameDay(date, new Date());
-
-                    return (
-                      <button
-                        key={date.toISOString()}
-                        id={`calendar-day-${format(date, "yyyy-MM-dd")}`}
-                        type="button"
+                      <span
+                        id={`calendar-day-number-${dateStr}`}
                         className={cn(
-                          "border-border bg-card group h-full min-h-0 cursor-pointer border-b p-1 text-left transition-colors sm:h-32 sm:p-2 lg:h-36",
-                          "focus-visible:ring-ring flex flex-col overflow-hidden focus-visible:ring-2 focus-visible:outline-none",
-                          !isToday && "hover:bg-muted/40",
-                          isToday && "bg-primary/5",
+                          "flex h-6 w-6 items-center justify-center rounded-md text-sm leading-none font-bold",
+                          "lg:h-7 lg:w-7 lg:text-base",
+                          isToday &&
+                            "bg-primary text-primary-foreground font-black",
+                          !isToday && isWeekendDay && !holiday && "text-destructive/70",
+                          !isToday && !isWeekendDay && !holiday && "text-foreground",
+                          !isToday && !!holiday && "text-foreground",
                         )}
-                        onClick={() => handleDayClick(date)}
-                        aria-label={`วันที่ ${format(date, "d MMMM yyyy", { locale: th })}`}
                       >
-                        <div className="mb-1 flex shrink-0 items-center justify-between sm:mb-2">
-                          <span
-                            id={`calendar-day-number-${format(date, "yyyy-MM-dd")}`}
-                            className={cn(
-                              "text-foreground flex h-7 w-7 items-center justify-center rounded-md text-lg leading-none font-black",
-                              "sm:h-8 sm:w-8 sm:text-2xl lg:h-9 lg:w-9 lg:text-3xl",
-                              isToday &&
-                                "border-primary bg-primary/10 text-primary ring-primary/25 border shadow-none ring-4",
-                            )}
+                        {format(date, "d")}
+                      </span>
+
+                      <div className="mt-0.5 min-h-0 flex-1 space-y-0.5 overflow-hidden lg:mt-1 lg:space-y-1">
+                        {holiday && (
+                          <div
+                            id={`calendar-holiday-${dateStr}`}
+                            className="bg-destructive/10 text-destructive flex items-center gap-1 rounded px-1 py-px text-[10px] font-semibold leading-tight lg:px-1.5 lg:py-0.5 lg:text-[11px]"
+                            title={holiday.nameThai}
                           >
-                            {format(date, "d")}
-                          </span>
-                        </div>
+                            <span className="bg-destructive text-destructive-foreground flex h-3 w-3 shrink-0 items-center justify-center rounded-full text-[8px] lg:h-3.5 lg:w-3.5">
+                              ★
+                            </span>
+                            <span className="min-w-0 truncate">
+                              {holiday.nameThai}
+                            </span>
+                          </div>
+                        )}
 
-                        <div className="min-h-0 flex-1 space-y-1 overflow-hidden">
-                          {holiday && (
-                            <div
-                              id={`calendar-holiday-${format(date, "yyyy-MM-dd")}`}
-                              className="bg-destructive/15 text-destructive flex min-w-0 items-center gap-1 rounded-md px-1.5 py-0.5 text-[10px] font-bold sm:gap-1.5 sm:px-2 sm:py-1 sm:text-xs"
-                              title={`${holiday.nameThai}${holiday.type !== "national" ? ` (${holiday.type})` : ""}`}
-                            >
-                              <span className="bg-destructive text-destructive-foreground flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-full text-[9px] sm:h-4 sm:w-4 sm:text-[10px]">
-                                ★
-                              </span>
-                              <span className="min-w-0 truncate">
-                                {holiday.nameThai}
-                                {holiday.type !== "national" &&
-                                  ` (${holiday.type})`}
-                              </span>
-                            </div>
-                          )}
+                        {leave && (
+                          <div
+                            id={`calendar-leave-${dateStr}`}
+                            className="bg-primary/10 text-primary flex items-center gap-1 rounded px-1 py-px text-[10px] font-semibold leading-tight lg:px-1.5 lg:py-0.5 lg:text-[11px]"
+                            title={`วันลา${renderLeaveType(leave.type)}`}
+                          >
+                            <span className="border-primary h-3 w-3 shrink-0 rounded-full border-[1.5px] lg:h-3.5 lg:w-3.5" />
+                            <span className="min-w-0 truncate">
+                              {renderLeaveType(leave.type)}
+                            </span>
+                          </div>
+                        )}
+                      </div>
+                    </button>
+                  );
+                })}
 
-                          {leave && (
-                            <div
-                              id={`calendar-leave-${format(date, "yyyy-MM-dd")}`}
-                              className="bg-primary/15 text-primary flex min-w-0 items-center gap-1 rounded-md px-1.5 py-0.5 text-[10px] font-bold sm:gap-1.5 sm:px-2 sm:py-1 sm:text-xs"
-                              title={`วันลา ${leave.type}`}
-                            >
-                              <span className="border-primary h-3.5 w-3.5 shrink-0 rounded-full border-2 sm:h-4 sm:w-4"></span>
-                              <span className="min-w-0 truncate">
-                                วันลา {leave.type === "personal" && "ลากิจ"}
-                                {leave.type === "sick" && "ลาป่วย"}
-                                {leave.type === "vacation" && "ลาพักผ่อน"}
-                                {!["personal", "sick", "vacation"].includes(
-                                  leave.type,
-                                ) && leave.type}
-                              </span>
-                            </div>
-                          )}
-                        </div>
-                      </button>
-                    );
-                  })}
-
-                  {Array.from({ length: trailingCellCount }).map((_, i) => (
-                    <div
-                      key={`trailing-${i}`}
-                      id={`calendar-trailing-cell-${i}`}
-                      className="border-border bg-muted/35 h-full min-h-0 border-b sm:h-32 lg:h-36"
-                    ></div>
-                  ))}
-                </div>
+                {Array.from({ length: trailingCellCount }).map((_, i) => (
+                  <div
+                    key={`trailing-${i}`}
+                    id={`calendar-trailing-cell-${i}`}
+                    className="border-border/50 bg-muted/20 border-b"
+                  />
+                ))}
               </div>
             </div>
           )}
-        </Card>
+        </div>
 
-        <section
-          id="calendar-statistics"
-          className="mt-5 hidden grid-cols-1 gap-4 sm:grid md:grid-cols-3"
-        >
-          <Card
-            id="calendar-stat-month"
-            className="border-border bg-card rounded-lg p-4 shadow-sm"
+        <div id="calendar-mobile-actions" className="mt-4 flex justify-center gap-2 sm:hidden">
+          <Button
+            id="calendar-mobile-leave-btn"
+            size="sm"
+            className="flex-1"
+            onClick={() => setShowLeaveModal(true)}
           >
-            <h3 className="mb-2 font-semibold dark:text-gray-100">
-              สถิติเดือนนี้
-            </h3>
-            <div className="space-y-2 text-sm dark:text-gray-300">
-              <div className="flex justify-between">
-                <span>วันหยุดราชการ:</span>
-                <span className="font-semibold">{holidayCount} วัน</span>
-              </div>
-              <div className="flex justify-between">
-                <span>วันลางาน:</span>
-                <span className="font-semibold">{leaveCount} วัน</span>
-              </div>
-              <div className="flex justify-between">
-                <span>วันทำงาน (โดยประมาณ):</span>
-                <span className="font-semibold">{workingDayCount} วัน</span>
-              </div>
-            </div>
-          </Card>
+            <Plus className="mr-1.5 h-3.5 w-3.5" />
+            แจ้งลา
+          </Button>
+          <Button
+            id="calendar-mobile-holiday-btn"
+            variant="outline"
+            size="sm"
+            className="flex-1"
+            onClick={() => setShowHolidayModal(true)}
+          >
+            <CalendarPlus className="mr-1.5 h-3.5 w-3.5" />
+            เพิ่มวันหยุด
+          </Button>
+          <Button
+            id="calendar-mobile-import-btn"
+            variant="outline"
+            size="sm"
+            className="flex-1"
+            onClick={() => setShowImportModal(true)}
+          >
+            <Upload className="mr-1.5 h-3.5 w-3.5" />
+            นำเข้า
+          </Button>
+        </div>
+      </div>
 
-          <Card
-            id="calendar-stat-year"
-            className="border-border bg-card rounded-lg p-4 shadow-sm"
-          >
-            <h3 className="mb-2 font-semibold dark:text-gray-100">
-              วันหยุดทั้งหมดในปี {buddhistYear}
-            </h3>
-            <div className="text-sm dark:text-gray-300">
-              <div className="flex justify-between">
-                <span>วันหยุดราชการ:</span>
-                <span className="font-semibold">
-                  {
-                    holidays.filter((h) => h.year === getYear(currentDate))
-                      .length
-                  }{" "}
-                  วัน
-                </span>
-              </div>
-            </div>
-          </Card>
-
-          <Card
-            id="calendar-manage-holidays-card"
-            className="border-border bg-card rounded-lg p-4 shadow-sm"
-          >
-            <h3 className="mb-2 font-semibold dark:text-gray-100">
-              จัดการวันหยุด
-            </h3>
-            <p className="text-muted-foreground mb-3 text-xs dark:text-gray-400">
-              Admin เท่านั้นที่สามารถจัดการวันหยุดได้
-            </p>
-            <div className="space-y-2">
-              <Button
-                id="calendar-import-holidays-secondary"
-                size="sm"
-                variant="outline"
-                className="w-full"
-                onClick={() => setShowImportModal(true)}
-              >
-                <Upload className="mr-2 h-4 w-4" />
-                นำเข้าวันหยุด
-              </Button>
-              <Button
-                id="calendar-add-holiday-secondary"
-                size="sm"
-                variant="default"
-                className="bg-destructive text-destructive-foreground hover:bg-destructive/90 w-full"
-                onClick={() => setShowHolidayModal(true)}
-              >
-                <CalendarPlus className="mr-2 h-4 w-4" />
-                เพิ่มวันหยุดใหม่
-              </Button>
-            </div>
-          </Card>
-        </section>
-      </main>
+      {showDayDetail && selectedDate && (
+        <DayDetailPanel
+          date={selectedDate}
+          holiday={getHolidayForDate(selectedDate)}
+          leave={getLeaveForDate(selectedDate)}
+          onClose={() => setShowDayDetail(false)}
+          onRequestLeave={() => {
+            setShowDayDetail(false);
+            setShowLeaveModal(true);
+          }}
+        />
+      )}
 
       {showImportModal && (
         <div id="calendar-import-modal-wrapper">

--- a/src/features/calendar/pages/MobileCalendarPage.tsx
+++ b/src/features/calendar/pages/MobileCalendarPage.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { useState, useEffect } from "react";
 import {
   format,
@@ -22,7 +20,6 @@ import {
   CalendarPlus,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 import { LeaveRequestModal } from "@/features/calendar/components/leave-request-modal";
 import { HolidayManageModal } from "@/features/calendar/components/holiday-manage-modal";
@@ -61,7 +58,6 @@ export function MobileCalendarPage() {
   const [showHolidayModal, setShowHolidayModal] = useState(false);
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
 
-  // Fetch holidays and leaves for current month
   useEffect(() => {
     const fetchData = async () => {
       setLoading(true);
@@ -69,7 +65,6 @@ export function MobileCalendarPage() {
       const month = getMonth(currentDate) + 1;
 
       try {
-        // Fetch holidays
         const holidaysRes = await fetch(`/api/holidays?year=${year}`);
         if (holidaysRes.ok) {
           const holidaysData = await holidaysRes.json();
@@ -78,7 +73,6 @@ export function MobileCalendarPage() {
           }
         }
 
-        // Fetch leaves
         const leavesRes = await fetch(
           `/api/leave?month=${year}-${month.toString().padStart(2, "0")}`,
         );
@@ -88,8 +82,7 @@ export function MobileCalendarPage() {
             setLeaves(leavesData.leaves);
           }
         }
-      } catch (error) {
-        console.error("Error fetching calendar data:", error);
+      } catch {
       } finally {
         setLoading(false);
       }
@@ -104,25 +97,24 @@ export function MobileCalendarPage() {
     );
   };
 
-  const handleExport = async (format: "json" | "csv") => {
+  const handleExport = async (exportFormat: "json" | "csv") => {
     const year = getYear(currentDate);
     try {
       const response = await fetch(
-        `/api/holidays?year=${year}&export=${format}`,
+        `/api/holidays?year=${year}&export=${exportFormat}`,
       );
       if (response.ok) {
         const blob = await response.blob();
         const url = window.URL.createObjectURL(blob);
         const a = document.createElement("a");
         a.href = url;
-        a.download = `holidays-${year}.${format}`;
+        a.download = `holidays-${year}.${exportFormat}`;
         document.body.appendChild(a);
         a.click();
         window.URL.revokeObjectURL(url);
         document.body.removeChild(a);
       }
-    } catch (error) {
-      console.error("Error exporting holidays:", error);
+    } catch {
     }
   };
 
@@ -132,12 +124,36 @@ export function MobileCalendarPage() {
     end: endOfMonth(currentDate),
   });
 
-  // Combine holidays and leaves into daily events
   const getEventsForDate = (date: Date) => {
     const dateStr = format(date, "yyyy-MM-dd");
     const holiday = holidays.find((h) => h.date === dateStr);
     const leave = leaves.find((l) => l.date === dateStr);
     return { holiday, leave, isToday: isSameDay(date, new Date()) };
+  };
+
+  const refreshLeaves = async () => {
+    const year = getYear(currentDate);
+    const month = getMonth(currentDate) + 1;
+    const leavesRes = await fetch(
+      `/api/leave?month=${year}-${month.toString().padStart(2, "0")}`,
+    );
+    if (leavesRes.ok) {
+      const leavesData = await leavesRes.json();
+      if (leavesData.success) {
+        setLeaves(leavesData.leaves);
+      }
+    }
+  };
+
+  const refreshHolidays = async () => {
+    const year = getYear(currentDate);
+    const holidaysRes = await fetch(`/api/holidays?year=${year}`);
+    if (holidaysRes.ok) {
+      const holidaysData = await holidaysRes.json();
+      if (holidaysData.success) {
+        setHolidays(holidaysData.holidays);
+      }
+    }
   };
 
   const handleLeaveRequest = async (data: {
@@ -155,28 +171,18 @@ export function MobileCalendarPage() {
       const result = await response.json();
 
       if (result.success) {
-        // Refresh leaves for current month
-        const year = getYear(currentDate);
-        const month = getMonth(currentDate) + 1;
-        const leavesRes = await fetch(
-          `/api/leave?month=${year}-${month.toString().padStart(2, "0")}`,
-        );
-        if (leavesRes.ok) {
-          const leavesData = await leavesRes.json();
-          if (leavesData.success) {
-            setLeaves(leavesData.leaves);
-          }
-        }
-        alert("✅ แจ้งลาสำเร็จ!");
+        await refreshLeaves();
+        alert("แจ้งลาสำเร็จ!");
       } else {
-        alert(`❌ ${result.message}`);
+        alert(result.message);
       }
-    } catch (err: any) {
-      alert(`❌ เกิดข้อผิดพลาด: ${err.message}`);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "เกิดข้อผิดพลาด";
+      alert(message);
     }
   };
 
-  const handleHolidayAdd = async (data: any) => {
+  const handleHolidayAdd = async (data: Holiday) => {
     try {
       const response = await fetch("/api/holidays", {
         method: "POST",
@@ -187,22 +193,22 @@ export function MobileCalendarPage() {
       const result = await response.json();
 
       if (result.success) {
-        // Refresh holidays for current year
-        const year = getYear(currentDate);
-        const holidaysRes = await fetch(`/api/holidays?year=${year}`);
-        if (holidaysRes.ok) {
-          const holidaysData = await holidaysRes.json();
-          if (holidaysData.success) {
-            setHolidays(holidaysData.holidays);
-          }
-        }
-        alert("✅ เพิ่มวันหยุดสำเร็จ!");
+        await refreshHolidays();
+        alert("เพิ่มวันหยุดสำเร็จ!");
       } else {
-        alert(`❌ ${result.message}`);
+        alert(result.message);
       }
-    } catch (err: any) {
-      alert(`❌ เกิดข้อผิดพลาด: ${err.message}`);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "เกิดข้อผิดพลาด";
+      alert(message);
     }
+  };
+
+  const renderLeaveType = (type: string) => {
+    if (type === "personal") return "ลากิจ";
+    if (type === "sick") return "ลาป่วย";
+    if (type === "vacation") return "ลาพักผ่อน";
+    return type;
   };
 
   const getFilteredEvents = () => {
@@ -231,44 +237,45 @@ export function MobileCalendarPage() {
   }).length;
   const todayEvent = days.find((date) => isSameDay(date, new Date()));
   const filterOptions = [
-    { value: "all", label: "ทั้งหมด", count: totalMarkedDays },
-    { value: "holidays", label: "วันหยุด", count: holidayCount },
-    { value: "leaves", label: "วันลา", count: leaveCount },
-  ] as const;
+    { value: "all" as const, label: "ทั้งหมด", count: totalMarkedDays },
+    { value: "holidays" as const, label: "วันหยุด", count: holidayCount },
+    { value: "leaves" as const, label: "วันลา", count: leaveCount },
+  ];
 
   return (
-    <div className="min-h-screen bg-[linear-gradient(180deg,#f8fafc_0%,#eef6f1_42%,#fff7ed_100%)] pb-28 text-slate-950 dark:bg-[linear-gradient(180deg,#07130f_0%,#101827_54%,#17130d_100%)] dark:text-slate-50">
+    <div id="mobile-calendar-page" className="bg-background min-h-screen pb-28">
       <header
-        id="calendar-header"
-        className="sticky top-0 z-10 border-b border-white/60 bg-white/85 px-4 pt-3 pb-4 shadow-sm backdrop-blur-xl dark:border-white/10 dark:bg-slate-950/80"
+        id="mobile-calendar-header"
+        className="border-border sticky top-0 z-10 border-b bg-background/90 px-4 py-3 backdrop-blur-md"
       >
         <nav
+          id="mobile-calendar-nav"
           className="flex items-center justify-between gap-4"
           aria-label="Calendar navigation"
         >
           <Button
-            id="prev-month-btn"
+            id="mobile-calendar-prev"
             onClick={() => navigateMonth("prev")}
-            variant="ghost"
+            variant="outline"
             size="icon"
-            className="h-10 w-10 rounded-lg border border-slate-200 bg-white/80 shadow-sm hover:bg-emerald-50 dark:border-slate-700 dark:bg-slate-900 dark:hover:bg-slate-800"
+            className="h-9 w-9 shrink-0"
             aria-label="เดือนก่อนหน้า"
           >
-            <ChevronLeft className="h-5 w-5" />
+            <ChevronLeft className="h-4 w-4" />
           </Button>
 
-          <div className="flex-1 text-center">
+          <div id="mobile-calendar-title" className="flex-1 text-center">
             <h1
-              id="current-month-display"
-              className="text-lg leading-tight font-bold text-slate-950 dark:text-slate-50"
+              id="mobile-calendar-month-year"
+              className="text-foreground text-base leading-tight font-bold"
               aria-live="polite"
               aria-atomic="true"
             >
               {format(currentDate, "MMMM yyyy", { locale: th })}
             </h1>
             <p
-              id="buddhist-year-display"
-              className="mt-0.5 text-xs font-medium text-emerald-700 dark:text-emerald-300"
+              id="mobile-calendar-buddhist-year"
+              className="text-muted-foreground mt-0.5 text-xs font-medium"
               aria-live="polite"
             >
               พ.ศ. {buddhistYear}
@@ -276,75 +283,97 @@ export function MobileCalendarPage() {
           </div>
 
           <Button
-            id="next-month-btn"
+            id="mobile-calendar-next"
             onClick={() => navigateMonth("next")}
-            variant="ghost"
+            variant="outline"
             size="icon"
-            className="h-10 w-10 rounded-lg border border-slate-200 bg-white/80 shadow-sm hover:bg-emerald-50 dark:border-slate-700 dark:bg-slate-900 dark:hover:bg-slate-800"
+            className="h-9 w-9 shrink-0"
             aria-label="เดือนถัดไป"
           >
-            <ChevronRight className="h-5 w-5" />
+            <ChevronRight className="h-4 w-4" />
           </Button>
         </nav>
       </header>
 
       <main
-        id="events-list"
-        className="space-y-5 px-4 py-5"
+        id="mobile-calendar-main"
+        className="space-y-4 px-4 py-4"
         role="main"
         aria-label="รายการวันหยุดและวันลา"
       >
         <section
-          className="overflow-hidden rounded-lg border border-white/70 bg-white/90 shadow-lg shadow-emerald-900/5 dark:border-white/10 dark:bg-slate-900/90 dark:shadow-black/20"
+          id="mobile-calendar-overview"
+          className="border-border overflow-hidden rounded-xl border bg-card"
           aria-label="ภาพรวมเดือน"
         >
-          <div className="border-b border-slate-200 bg-[linear-gradient(135deg,#0f766e_0%,#16a34a_52%,#f59e0b_100%)] p-4 text-white dark:border-white/10">
+          <div
+            id="mobile-calendar-overview-header"
+            className="border-border border-b bg-muted/50 px-4 py-3"
+          >
             <div className="flex items-start justify-between gap-3">
               <div>
-                <p className="text-xs font-semibold tracking-[0.16em] text-white/75 uppercase">
+                <p
+                  id="mobile-calendar-eyebrow"
+                  className="text-muted-foreground text-[10px] font-semibold tracking-[0.16em] uppercase"
+                >
                   ปฏิทินทีม
                 </p>
-                <h2 className="mt-2 text-2xl leading-tight font-black">
+                <h2
+                  id="mobile-calendar-month-name"
+                  className="text-foreground mt-1.5 text-xl leading-tight font-black"
+                >
                   {format(currentDate, "MMMM", { locale: th })}
                 </h2>
-                <p className="mt-1 text-sm font-medium text-white/85">
+                <p
+                  id="mobile-calendar-summary"
+                  className="text-muted-foreground mt-1 text-xs font-medium"
+                >
                   วันหยุด {holidayCount} วัน · วันลา {leaveCount} วัน
                 </p>
               </div>
-              <div className="rounded-lg border border-white/25 bg-white/15 px-3 py-2 text-center backdrop-blur">
-                <CalendarIcon className="mx-auto h-5 w-5" aria-hidden="true" />
-                <p className="mt-1 text-xs font-semibold">พ.ศ.</p>
-                <p className="text-lg leading-none font-black">
+              <div
+                id="mobile-calendar-year-badge"
+                className="border-border rounded-md border bg-background px-2.5 py-2 text-center"
+              >
+                <CalendarIcon
+                  className="text-muted-foreground mx-auto h-4 w-4"
+                  aria-hidden="true"
+                />
+                <p className="text-muted-foreground mt-0.5 text-[10px] font-semibold">พ.ศ.</p>
+                <p id="mobile-calendar-buddhist-year-badge" className="text-foreground text-base leading-none font-black">
                   {buddhistYear}
                 </p>
               </div>
             </div>
           </div>
 
-          <div className="grid grid-cols-3 divide-x divide-slate-200 dark:divide-slate-800">
-            <div className="px-3 py-3">
-              <p className="text-xs font-medium text-slate-500 dark:text-slate-400">
+          <div
+            id="mobile-calendar-stats"
+            className="grid grid-cols-3 divide-x divide-border"
+          >
+            <div id="mobile-calendar-stat-today" className="px-3 py-2.5">
+              <p className="text-muted-foreground text-[10px] font-medium">
                 วันนี้
               </p>
-              <p className="mt-1 truncate text-sm font-bold text-slate-950 dark:text-slate-50">
+              <p className="text-foreground mt-0.5 truncate text-sm font-bold">
                 {todayEvent
                   ? format(todayEvent, "d MMM", { locale: th })
                   : "นอกเดือนนี้"}
               </p>
             </div>
-            <div className="px-3 py-3">
-              <p className="text-xs font-medium text-slate-500 dark:text-slate-400">
+            <div id="mobile-calendar-stat-holidays" className="px-3 py-2.5">
+              <p className="text-muted-foreground text-[10px] font-medium">
                 วันหยุด
               </p>
-              <p className="mt-1 text-sm font-bold text-rose-700 dark:text-rose-300">
+              <p className="text-destructive mt-0.5 text-sm font-bold">
                 {holidayCount} รายการ
               </p>
             </div>
-            <div className="px-3 py-3">
-              <p className="text-xs font-medium text-slate-500 dark:text-slate-400">
+            <div id="mobile-calendar-stat-leaves" className="px-3 py-2.5">
+              <p className="text-muted-foreground text-[10px] font-medium">
                 วันลา
               </p>
-              <p className="mt-1 text-sm font-bold text-sky-700 dark:text-sky-300">
+              <p className="text-primary mt-0.5 text-sm font-bold">
                 {leaveCount} รายการ
               </p>
             </div>
@@ -352,24 +381,31 @@ export function MobileCalendarPage() {
         </section>
 
         <section
+          id="mobile-calendar-filters"
           aria-label="ตัวกรองรายการ"
           className="flex gap-2 overflow-x-auto pb-1"
         >
           {filterOptions.map((option) => (
             <button
               key={option.value}
+              id={`mobile-calendar-filter-${option.value}`}
               type="button"
               onClick={() => setFilter(option.value)}
               className={cn(
-                "min-h-10 shrink-0 rounded-lg border px-4 text-sm font-bold transition-colors",
+                "min-h-9 shrink-0 rounded-md border px-3 text-xs font-bold transition-colors",
                 filter === option.value
-                  ? "border-emerald-700 bg-emerald-700 text-white shadow-md shadow-emerald-900/15 dark:border-emerald-400 dark:bg-emerald-400 dark:text-slate-950"
-                  : "border-slate-200 bg-white/85 text-slate-700 hover:bg-white dark:border-slate-700 dark:bg-slate-900/80 dark:text-slate-200 dark:hover:bg-slate-800",
+                  ? "border-primary bg-primary text-primary-foreground"
+                  : "border-border bg-background text-foreground hover:bg-muted/50",
               )}
               aria-pressed={filter === option.value}
             >
               {option.label}
-              <span className="ml-2 rounded-md bg-black/10 px-1.5 py-0.5 text-xs dark:bg-white/15">
+              <span className={cn(
+                "ml-1.5 rounded px-1 py-px text-[10px]",
+                filter === option.value
+                  ? "bg-primary-foreground/20 text-primary-foreground"
+                  : "bg-muted text-muted-foreground",
+              )}>
                 {option.count}
               </span>
             </button>
@@ -378,48 +414,49 @@ export function MobileCalendarPage() {
 
         {loading ? (
           <div
-            id="loading-indicator"
-            className="rounded-lg border border-white/70 bg-white/85 py-12 text-center shadow-sm dark:border-white/10 dark:bg-slate-900/85"
+            id="mobile-calendar-loading"
+            className="border-border rounded-xl border bg-card py-12 text-center"
             role="status"
             aria-live="polite"
             aria-busy="true"
           >
             <div
-              className="inline-block h-10 w-10 animate-spin rounded-full border-4 border-emerald-200 border-b-emerald-700 dark:border-emerald-900 dark:border-b-emerald-300"
+              id="mobile-calendar-spinner"
+              className="border-primary inline-block h-8 w-8 animate-spin rounded-full border-2 border-b-transparent"
               aria-hidden="true"
-            ></div>
-            <p className="mt-3 text-sm font-semibold text-slate-600 dark:text-slate-300">
+            />
+            <p className="text-muted-foreground mt-3 text-sm font-medium">
               กำลังโหลด...
             </p>
           </div>
         ) : filteredEvents.length === 0 ? (
-          <Card
-            id="no-events-message"
-            className="border-dashed border-slate-300 bg-white/85 p-8 text-center shadow-sm dark:border-slate-700 dark:bg-slate-900/85"
+          <div
+            id="mobile-calendar-empty"
+            className="border-border border-dashed rounded-xl border bg-card p-8 text-center"
             role="status"
             aria-live="polite"
           >
-            <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-lg bg-emerald-50 text-2xl dark:bg-emerald-950/40">
+            <div className="bg-muted mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-lg">
               <CalendarIcon
-                className="h-7 w-7 text-emerald-700 dark:text-emerald-300"
+                className="text-muted-foreground h-6 w-6"
                 aria-hidden="true"
               />
             </div>
-            <p className="text-base font-bold text-slate-800 dark:text-slate-100">
+            <p id="mobile-calendar-empty-title" className="text-foreground text-sm font-bold">
               {filter === "all"
                 ? "ไม่มีวันหยุดหรือวันลาในเดือนนี้"
                 : filter === "holidays"
                   ? "ไม่มีวันหยุดในเดือนนี้"
                   : "ไม่มีวันลาในเดือนนี้"}
             </p>
-            <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
+            <p id="mobile-calendar-empty-hint" className="text-muted-foreground mt-1.5 text-xs">
               ลองเปลี่ยนตัวกรองหรือเพิ่มรายการใหม่
             </p>
-          </Card>
+          </div>
         ) : (
           <ul
-            id="events-list-ul"
-            className="space-y-3"
+            id="mobile-calendar-events-list"
+            className="space-y-2.5"
             role="list"
             aria-label="รายการวันที่และเหตุการณ์"
           >
@@ -434,51 +471,50 @@ export function MobileCalendarPage() {
               return (
                 <li
                   key={date.toISOString()}
-                  id={`event-${dateStr}`}
+                  id={`mobile-event-${dateStr}`}
                   className={cn(
-                    "overflow-hidden rounded-lg border bg-white/92 shadow-sm transition-transform duration-200 active:scale-[0.99] dark:bg-slate-900/90",
-                    holiday &&
-                      !leave &&
-                      "border-rose-200 dark:border-rose-900/70",
-                    leave &&
-                      !holiday &&
-                      "border-sky-200 dark:border-sky-900/70",
-                    isMixed && "border-amber-300 dark:border-amber-800",
-                    isToday &&
-                      "ring-2 ring-emerald-600 ring-offset-2 ring-offset-transparent dark:ring-emerald-300",
+                    "border-border overflow-hidden rounded-xl border bg-card transition-transform duration-150 active:scale-[0.99]",
+                    holiday && !leave && "border-destructive/30",
+                    leave && !holiday && "border-primary/30",
+                    isMixed && "border-accent/30",
+                    isToday && "ring-primary ring-2 ring-offset-1 ring-offset-background",
                   )}
                   role="listitem"
                   aria-label={`${dayOfWeek}ที่ ${format(date, "d")} ${format(date, "MMMM", { locale: th })}`}
                 >
                   <div
-                    id={`event-header-${dateStr}`}
+                    id={`mobile-event-header-${dateStr}`}
                     className={cn(
-                      "flex items-center justify-between gap-3 border-b px-4 py-3 dark:border-slate-800",
-                      holiday && !leave && "bg-rose-50/90 dark:bg-rose-950/25",
-                      leave && !holiday && "bg-sky-50/90 dark:bg-sky-950/25",
-                      isMixed && "bg-amber-50/90 dark:bg-amber-950/25",
-                      !holiday && !leave && "bg-slate-50 dark:bg-slate-800/60",
+                      "border-border flex items-center justify-between gap-3 border-b px-3.5 py-2.5",
+                      holiday && !leave && "bg-destructive/[0.04]",
+                      leave && !holiday && "bg-primary/[0.04]",
+                      isMixed && "bg-accent/[0.04]",
+                      !holiday && !leave && "bg-muted/30",
                     )}
                   >
                     <div className="flex min-w-0 items-center gap-3">
-                      <div className="min-w-12 text-center" aria-hidden="true">
-                        <p className="text-3xl leading-none font-black text-slate-950 dark:text-slate-50">
+                      <div
+                        id={`mobile-event-date-${dateStr}`}
+                        className="min-w-11 text-center"
+                        aria-hidden="true"
+                      >
+                        <p className="text-foreground text-2xl leading-none font-black">
                           {format(date, "d")}
                         </p>
-                        <p className="mt-1 text-xs font-bold text-slate-500 uppercase dark:text-slate-400">
+                        <p className="text-muted-foreground mt-0.5 text-[10px] font-bold uppercase">
                           {format(date, "MMM", { locale: th })}
                         </p>
                       </div>
                       <div className="min-w-0">
                         <p
-                          id={`day-name-${dateStr}`}
-                          className="truncate text-base font-extrabold text-slate-950 dark:text-slate-50"
+                          id={`mobile-event-day-name-${dateStr}`}
+                          className="text-foreground truncate text-sm font-bold"
                         >
                           {dayOfWeek}
                         </p>
                         <p
-                          id={`full-date-${dateStr}`}
-                          className="text-xs font-medium text-slate-500 dark:text-slate-400"
+                          id={`mobile-event-full-date-${dateStr}`}
+                          className="text-muted-foreground text-xs font-medium"
                         >
                           {format(date, "MMMM yyyy", { locale: th })}
                         </p>
@@ -487,8 +523,8 @@ export function MobileCalendarPage() {
 
                     {isToday && (
                       <span
-                        id="today-indicator"
-                        className="shrink-0 rounded-md border border-emerald-700/20 bg-emerald-100 px-2.5 py-1 text-xs font-bold text-emerald-800 dark:border-emerald-300/20 dark:bg-emerald-950 dark:text-emerald-200"
+                        id={`mobile-event-today-${dateStr}`}
+                        className="bg-primary/10 text-primary shrink-0 rounded-md px-2 py-0.5 text-[10px] font-bold"
                         aria-label="วันนี้"
                       >
                         วันนี้
@@ -497,34 +533,34 @@ export function MobileCalendarPage() {
                   </div>
 
                   <div
-                    id={`event-content-${dateStr}`}
-                    className="space-y-3 p-4"
+                    id={`mobile-event-content-${dateStr}`}
+                    className="space-y-2.5 p-3.5"
                     role="group"
                     aria-label="ข้อมูลเหตุการณ์"
                   >
                     {holiday && (
                       <div
-                        id={`holiday-${dateStr}`}
-                        className="flex items-start gap-3"
+                        id={`mobile-event-holiday-${dateStr}`}
+                        className="flex items-start gap-2.5"
                         role="group"
                         aria-label={`วันหยุด: ${holiday.nameThai}`}
                       >
                         <div
-                          className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-rose-100 text-rose-700 dark:bg-rose-950 dark:text-rose-200"
+                          className="bg-destructive/10 text-destructive flex h-9 w-9 shrink-0 items-center justify-center rounded-lg"
                           aria-hidden="true"
                         >
-                          <CalendarIcon className="h-5 w-5" />
+                          <CalendarIcon className="h-4 w-4" />
                         </div>
                         <div className="min-w-0 flex-1">
                           <div
-                            id={`holiday-name-th-${dateStr}`}
-                            className="text-base font-bold text-slate-950 dark:text-slate-50"
+                            id={`mobile-event-holiday-name-th-${dateStr}`}
+                            className="text-foreground text-sm font-bold"
                           >
                             {holiday.nameThai}
                           </div>
                           <div
-                            id={`holiday-name-en-${dateStr}`}
-                            className="mt-0.5 line-clamp-2 text-sm text-slate-500 dark:text-slate-400"
+                            id={`mobile-event-holiday-name-en-${dateStr}`}
+                            className="text-muted-foreground mt-0.5 line-clamp-2 text-xs"
                           >
                             {holiday.nameEnglish}
                           </div>
@@ -534,33 +570,28 @@ export function MobileCalendarPage() {
 
                     {leave && (
                       <div
-                        id={`leave-${dateStr}`}
-                        className="flex items-start gap-3"
+                        id={`mobile-event-leave-${dateStr}`}
+                        className="flex items-start gap-2.5"
                         role="group"
-                        aria-label={`วันลา: ${leave.type === "personal" ? "ลากิจ" : leave.type === "sick" ? "ลาป่วย" : "ลาพักผ่อน"}`}
+                        aria-label={`วันลา: ${renderLeaveType(leave.type)}`}
                       >
                         <div
-                          className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-sky-100 text-sky-700 dark:bg-sky-950 dark:text-sky-200"
+                          className="bg-primary/10 text-primary flex h-9 w-9 shrink-0 items-center justify-center rounded-lg"
                           aria-hidden="true"
                         >
-                          <Plus className="h-5 w-5" />
+                          <Plus className="h-4 w-4" />
                         </div>
                         <div className="min-w-0 flex-1">
                           <div
-                            id={`leave-type-${dateStr}`}
-                            className="text-base font-bold text-slate-950 dark:text-slate-50"
+                            id={`mobile-event-leave-type-${dateStr}`}
+                            className="text-foreground text-sm font-bold"
                           >
-                            {leave.type === "personal" && "ลากิจ"}
-                            {leave.type === "sick" && "ลาป่วย"}
-                            {leave.type === "vacation" && "ลาพักผ่อน"}
-                            {!["personal", "sick", "vacation"].includes(
-                              leave.type,
-                            ) && leave.type}
+                            {renderLeaveType(leave.type)}
                           </div>
                           {leave.reason && (
                             <div
-                              id={`leave-reason-${dateStr}`}
-                              className="mt-0.5 line-clamp-2 text-sm text-slate-500 dark:text-slate-400"
+                              id={`mobile-event-leave-reason-${dateStr}`}
+                              className="text-muted-foreground mt-0.5 line-clamp-2 text-xs"
                             >
                               {leave.reason}
                             </div>
@@ -570,9 +601,10 @@ export function MobileCalendarPage() {
                     )}
 
                     <Button
+                      id={`mobile-event-request-leave-${dateStr}`}
                       type="button"
                       variant="outline"
-                      className="mt-1 h-10 w-full rounded-lg border-slate-200 bg-white text-sm font-bold text-slate-700 hover:bg-emerald-50 hover:text-emerald-800 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800"
+                      className="mt-0.5 h-9 w-full rounded-lg text-xs font-bold"
                       onClick={() => {
                         setSelectedDate(dateStr);
                         setShowLeaveModal(true);
@@ -589,15 +621,15 @@ export function MobileCalendarPage() {
       </main>
 
       <nav
-        id="fab-buttons"
-        className="fixed inset-x-3 bottom-3 z-50 grid grid-cols-3 gap-2 rounded-lg border border-white/70 bg-white/92 p-2 shadow-2xl shadow-slate-900/15 backdrop-blur-xl dark:border-white/10 dark:bg-slate-950/90"
+        id="mobile-calendar-fab"
+        className="border-border bg-card fixed inset-x-3 bottom-3 z-50 grid grid-cols-3 gap-2 rounded-xl border p-2"
         role="navigation"
         aria-label="ปุ่มดำเนินการด่วน"
       >
         <Button
-          id="request-leave-fab"
+          id="mobile-fab-leave"
           size="sm"
-          className="h-12 rounded-lg bg-sky-700 text-xs font-bold hover:bg-sky-800 dark:bg-sky-500 dark:text-slate-950 dark:hover:bg-sky-400"
+          className="h-11 rounded-lg text-xs font-bold"
           onClick={() => {
             setSelectedDate(null);
             setShowLeaveModal(true);
@@ -608,9 +640,10 @@ export function MobileCalendarPage() {
           ลางาน
         </Button>
         <Button
-          id="add-holiday-fab"
+          id="mobile-fab-holiday"
           size="sm"
-          className="h-12 rounded-lg bg-rose-700 text-xs font-bold hover:bg-rose-800 dark:bg-rose-500 dark:text-slate-950 dark:hover:bg-rose-400"
+          variant="outline"
+          className="h-11 rounded-lg text-xs font-bold"
           onClick={() => {
             setSelectedDate(null);
             setShowHolidayModal(true);
@@ -621,9 +654,10 @@ export function MobileCalendarPage() {
           วันหยุด
         </Button>
         <Button
-          id="export-holidays-fab"
+          id="mobile-fab-export"
           size="sm"
-          className="h-12 rounded-lg bg-emerald-700 text-xs font-bold hover:bg-emerald-800 dark:bg-emerald-400 dark:text-slate-950 dark:hover:bg-emerald-300"
+          variant="outline"
+          className="h-11 rounded-lg text-xs font-bold"
           onClick={() => handleExport("json")}
           aria-label="ส่งออกข้อมูลวันหยุด"
         >
@@ -632,9 +666,8 @@ export function MobileCalendarPage() {
         </Button>
       </nav>
 
-      {/* Leave Request Modal */}
       {showLeaveModal && (
-        <div id="leave-request-modal-wrapper">
+        <div id="mobile-leave-modal-wrapper">
           <LeaveRequestModal
             isOpen={showLeaveModal}
             onClose={() => setShowLeaveModal(false)}
@@ -644,9 +677,8 @@ export function MobileCalendarPage() {
         </div>
       )}
 
-      {/* Holiday Management Modal */}
       {showHolidayModal && (
-        <div id="holiday-manage-modal-wrapper">
+        <div id="mobile-holiday-modal-wrapper">
           <HolidayManageModal
             isOpen={showHolidayModal}
             onClose={() => setShowHolidayModal(false)}

--- a/src/features/calendar/pages/MobileCalendarPage.tsx
+++ b/src/features/calendar/pages/MobileCalendarPage.tsx
@@ -182,7 +182,7 @@ export function MobileCalendarPage() {
     }
   };
 
-  const handleHolidayAdd = async (data: Holiday) => {
+  const handleHolidayAdd = async (data: Omit<Holiday, "id">) => {
     try {
       const response = await fetch("/api/holidays", {
         method: "POST",


### PR DESCRIPTION
## Summary
- Redesign calendar desktop/mobile pages to comply with DESIGN.md (remove hero-metric cards, identical card grids, hardcoded colors)
- Add `DayDetailPanel` component for click-to-view event details (holiday name TH/EN, type, leave reason)
- Replace all hardcoded `dark:text-gray-*`, `emerald-*`, `sky-*`, `rose-*` colors with theme tokens
- Add skeleton loading grid, proper id tags on all elements, inline summary replacing stat cards
- Update CHANGELOG.md for v1.5.0

## Changes
- `CalendarPage.tsx` — full redesign, DayDetailPanel, skeleton, id tags
- `MobileCalendarPage.tsx` — theme tokens, id tags, remove gradient bg
- `holiday-manage-modal.tsx` — theme tokens replace dark:gray-*
- `holiday-import.tsx` — theme tokens replace dark:gray-*
- `CHANGELOG.md` — v1.5.0 entry

## Test plan
- [ ] Desktop calendar renders with inline summary (no hero-metric cards)
- [ ] Clicking a day with holiday/leave opens DayDetailPanel with full details
- [ ] Clicking a day without events opens leave request modal directly
- [ ] Mobile calendar uses theme tokens, not hardcoded colors
- [ ] Dark mode works correctly on all calendar components
- [ ] All id attributes present for test targeting