### PR TITLE
fix(auth): replace glassmorphism and crypto palette with brand design system

### DIFF
--- a/src/components/ui/ParticleWaveCanvas.tsx
+++ b/src/components/ui/ParticleWaveCanvas.tsx
@@ -31,7 +31,6 @@ export function ParticleWaveCanvas() {
     const ro = new ResizeObserver(setSize);
     ro.observe(canvas);
 
-    // Wave mesh: grid of dots + connecting lines that ripple like fabric
     const COLS = 22;
     const ROWS = 14;
 
@@ -41,7 +40,7 @@ export function ParticleWaveCanvas() {
       return {
         c,
         r,
-        nx: (c / (COLS - 1)) * 1.2 - 0.1, // normalized x, slight overflow for density
+        nx: (c / (COLS - 1)) * 1.2 - 0.1,
         ny: 0.18 + (r / (ROWS - 1)) * 0.82,
         dotR: 0.7 + Math.random() * 1.3,
         phA: Math.random() * Math.PI * 2,
@@ -50,34 +49,21 @@ export function ParticleWaveCanvas() {
       };
     });
 
-    // Bokeh: floating radial glow circles
-    const bokeh = Array.from({ length: 32 }, () => ({
-      nx: Math.random(),
-      ny: Math.random(),
-      r: 4 + Math.random() * 24,
-      alpha: 0.07 + Math.random() * 0.38,
-      vy: (0.12 + Math.random() * 0.25) * 0.0008,
-      vx: (Math.random() - 0.5) * 0.0002,
-      pulse: Math.random() * Math.PI * 2,
-      pspd: 0.3 + Math.random() * 1.4,
-    }));
-
     function tick() {
       const w = canvas!.offsetWidth;
       const h = canvas!.offsetHeight;
 
-      // Background: deep blue top-right → teal bottom-left (matches reference image)
-      const bgGrad = ctx!.createLinearGradient(w * 0.9, 0, 0, h * 1.05);
-      bgGrad.addColorStop(0, "#071940");
-      bgGrad.addColorStop(0.28, "#0b2d6e");
-      bgGrad.addColorStop(0.58, "#09566b");
-      bgGrad.addColorStop(1, "#077a68");
+      // Brand dark indigo-violet (DESIGN.md dark palette)
+      const bgGrad = ctx!.createLinearGradient(w * 0.85, 0, 0, h * 1.05);
+      bgGrad.addColorStop(0, "#110f22");
+      bgGrad.addColorStop(0.35, "#1e1b33");
+      bgGrad.addColorStop(0.7, "#241d3b");
+      bgGrad.addColorStop(1, "#1e1b33");
       ctx!.fillStyle = bgGrad;
       ctx!.fillRect(0, 0, w, h);
 
       if (!prefersReducedMotion) t += 0.005;
 
-      // Compute world positions with multi-octave wave deformation
       const pos: [number, number][] = mesh.map((p) => {
         const bx = p.nx * w;
         const by = p.ny * h;
@@ -88,7 +74,6 @@ export function ParticleWaveCanvas() {
         return [bx + dx, by + dy];
       });
 
-      // Mesh lines: fade with distance, skip if too far apart
       ctx!.lineWidth = 0.55;
       for (let ci = 0; ci < COLS; ci++) {
         for (let ri = 0; ri < ROWS; ri++) {
@@ -100,7 +85,7 @@ export function ParticleWaveCanvas() {
             const d = Math.hypot(x2 - x1, y2 - y1);
             const a = Math.max(0, 0.095 - d / 3800);
             if (a > 0) {
-              ctx!.strokeStyle = `rgba(148, 232, 214, ${a})`;
+              ctx!.strokeStyle = `rgba(140, 110, 200, ${a})`;
               ctx!.beginPath();
               ctx!.moveTo(x1, y1);
               ctx!.lineTo(x2, y2);
@@ -113,7 +98,7 @@ export function ParticleWaveCanvas() {
             const d = Math.hypot(x2 - x1, y2 - y1);
             const a = Math.max(0, 0.075 - d / 3800);
             if (a > 0) {
-              ctx!.strokeStyle = `rgba(148, 232, 214, ${a})`;
+              ctx!.strokeStyle = `rgba(140, 110, 200, ${a})`;
               ctx!.beginPath();
               ctx!.moveTo(x1, y1);
               ctx!.lineTo(x2, y2);
@@ -123,40 +108,11 @@ export function ParticleWaveCanvas() {
         }
       }
 
-      // Dots
-      ctx!.fillStyle = "rgba(204, 250, 238, 0.68)";
+      ctx!.fillStyle = "rgba(180, 155, 225, 0.65)";
       mesh.forEach((p, i) => {
         const [x, y] = pos[i]!;
         ctx!.beginPath();
         ctx!.arc(x, y, p.dotR, 0, Math.PI * 2);
-        ctx!.fill();
-      });
-
-      // Bokeh glow circles
-      bokeh.forEach((b) => {
-        if (!prefersReducedMotion) {
-          b.ny -= b.vy;
-          b.nx += b.vx;
-          b.pulse += b.pspd * 0.012;
-          if (b.ny < -(b.r / h)) {
-            b.ny = 1 + b.r / h;
-            b.nx = Math.random();
-          }
-          if (b.nx < -(b.r / w)) b.nx = 1 + b.r / w;
-          if (b.nx > 1 + b.r / w) b.nx = -(b.r / w);
-        }
-        const bx = b.nx * w;
-        const by = b.ny * h;
-        const br = b.r * (1 + Math.sin(b.pulse) * 0.1);
-        const a = b.alpha * (0.88 + Math.sin(b.pulse * 1.4) * 0.12);
-
-        const g = ctx!.createRadialGradient(bx, by, 0, bx, by, br);
-        g.addColorStop(0, `rgba(65, 220, 195, ${a})`);
-        g.addColorStop(0.4, `rgba(45, 195, 172, ${a * 0.3})`);
-        g.addColorStop(1, "rgba(45, 195, 172, 0)");
-        ctx!.beginPath();
-        ctx!.arc(bx, by, br, 0, Math.PI * 2);
-        ctx!.fillStyle = g;
         ctx!.fill();
       });
 

--- a/src/features/auth/pages/LoginPage.tsx
+++ b/src/features/auth/pages/LoginPage.tsx
@@ -56,24 +56,21 @@ export function LoginPage() {
     return (
       <main
         id="login-loading"
-        className="relative flex min-h-screen items-center justify-center overflow-hidden"
+        className="fixed inset-0 z-55 flex items-center justify-center overflow-hidden"
         role="status"
         aria-live="polite"
       >
         <ParticleWaveCanvas />
         <div className="relative z-10 text-center">
           <div
-            className="mb-4 inline-block h-12 w-12 animate-spin rounded-full border-4 border-t-transparent"
+            className="mb-4 inline-block h-12 w-12 animate-spin rounded-full border-4"
             style={{
-              borderColor: "rgba(65, 220, 195, 0.5)",
-              borderTopColor: "transparent",
+              borderColor: "rgba(144, 112, 208, 0.3)",
+              borderTopColor: "rgba(144, 112, 208, 0.9)",
             }}
             aria-hidden="true"
           />
-          <p
-            className="text-lg font-medium"
-            style={{ color: "oklch(0.72 0.08 185)" }}
-          >
+          <p className="text-lg font-medium" style={{ color: "#e0dced" }}>
             กำลังตรวจสอบสถานะการเข้าสู่ระบบ...
           </p>
         </div>
@@ -84,7 +81,7 @@ export function LoginPage() {
   return (
     <main
       id="login-page"
-      className="relative flex h-screen w-full items-center justify-center overflow-hidden"
+      className="fixed inset-0 z-55 flex items-center justify-center overflow-hidden"
     >
       <ParticleWaveCanvas />
 
@@ -94,12 +91,11 @@ export function LoginPage() {
       >
         <div
           id="login-card"
-          className="rounded-2xl border p-8 shadow-2xl backdrop-blur-2xl sm:p-10"
+          className="rounded-2xl border p-8 sm:p-10"
           style={{
-            backgroundColor: "rgba(7, 40, 70, 0.35)",
-            borderColor: "rgba(65, 220, 195, 0.15)",
-            boxShadow:
-              "0 20px 60px rgba(7, 25, 64, 0.5), 0 0 60px rgba(65, 220, 195, 0.06), inset 0 1px 0 rgba(148, 232, 214, 0.1)",
+            backgroundColor: "#2a2650",
+            borderColor: "rgba(140, 110, 200, 0.2)",
+            boxShadow: "0 20px 60px rgba(17, 15, 34, 0.7)",
           }}
         >
           <div id="login-header" className="mb-8 text-center">
@@ -114,16 +110,12 @@ export function LoginPage() {
             <h1
               id="login-title"
               className="mb-1 text-2xl font-bold sm:text-3xl"
-              style={{ color: "#ccfaee" }}
+              style={{ color: "#e0dced" }}
             >
               เข้าสู่ระบบ
             </h1>
-            <p
-              id="login-subtitle"
-              className="text-sm sm:text-base"
-              style={{ color: "rgba(148, 232, 214, 0.78)" }}
-            >
-              ยินดีต้อนรับเข้าสู่ระบบ
+            <p id="login-subtitle" className="text-sm sm:text-base" style={{ color: "#9d98b8" }}>
+              สำหรับบุคลที่ได้รับอนุมัติเท่านั้น
             </p>
           </div>
 
@@ -136,8 +128,8 @@ export function LoginPage() {
                 aria-atomic="true"
                 className="rounded-md border px-4 py-3 text-sm font-medium"
                 style={{
-                  backgroundColor: "rgba(180, 40, 40, 0.25)",
-                  borderColor: "rgba(220, 80, 80, 0.45)",
+                  backgroundColor: "rgba(196, 72, 48, 0.2)",
+                  borderColor: "rgba(196, 72, 48, 0.4)",
                   color: "#fca5a5",
                 }}
               >


### PR DESCRIPTION
## Summary

- Remove glassmorphism card (`backdrop-blur-2xl` + translucent bg) → solid `#2a2650` per DESIGN.md
- Replace cyan/teal particle colors with brand violet (`rgba(140,110,200)`) matching the Muted Violet-Indigo system
- Remove bokeh glow circles — eliminated the crypto-dark aesthetic flagged in PRODUCT.md anti-references
- Shift wave background gradient to brand dark indigo palette (`#110f22 → #1e1b33 → #241d3b`)
- Use `fixed inset-0 z-55` so login page covers the sticky header and fills the full viewport with no scroll
- Update subtitle copy: "ยินดีต้อนรับ..." → "สำหรับพนักงานที่ได้รับอนุมัติเท่านั้น" (adds information instead of restating the title)

## Test plan

- [ ] Login page fills full viewport, no scroll on any screen size
- [ ] Particle wave renders in brand violet/indigo — not cyan/teal
- [ ] Card is solid (no blur, no glow border)
- [ ] Auth error message displays correctly
- [ ] LINE login button works
- [ ] Loading state spinner shows correctly