### PR TITLE
fix(expenses): re-apply co-payment 60/40 when editing ทชท transactions

### DIFF
--- a/src/features/expenses/components/AddTransactionModal.tsx
+++ b/src/features/expenses/components/AddTransactionModal.tsx
@@ -9,6 +9,12 @@ import { PopoverDatePicker } from "@/components/ui/date-picker";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { toTransDate } from "@/features/expenses/helpers";
+import {
+  shouldApplyCoPayment,
+  calculateCoPaymentSplit,
+  formatCoPaymentDetails,
+  parseTransactionSubsidy,
+} from "@/features/expenses/helpers/coPayment";
 import type {
   CreateTransactionInput,
   ExpenseCategory,
@@ -62,15 +68,41 @@ export function AddTransactionModal({
   const [tags, setTags] = useState("");
   const [transDate, setTransDate] = useState(() => toTransDate());
 
+  const isCoPayTx =
+    !!editData &&
+    shouldApplyCoPayment(
+      editData.type,
+      editData.note,
+      editData.tags?.split(","),
+    );
+
   useEffect(() => {
     if (open) {
       if (editData) {
         setType(editData.type);
         setCategoryId(editData.categoryId);
-        setAmount(formatAmount(editData.amount.toString()));
-        setNote(editData.note ?? "");
-        setTags(editData.tags ?? "");
         setTransDate(editData.transDate);
+
+        if (isCoPayTx) {
+          const subsidy = parseTransactionSubsidy(
+            editData.amount,
+            editData.note,
+            editData.tags,
+          );
+          setAmount(formatAmount((editData.amount + subsidy).toString()));
+          const customNoteMatch = (editData.note ?? "").match(/ - (.+)$/);
+          setNote(customNoteMatch?.[1] ?? "");
+          const customTags = (editData.tags ?? "")
+            .split(",")
+            .map((t) => t.trim())
+            .filter((t) => t && t !== "ไทยช่วยไทย" && t !== "60-40")
+            .join(",");
+          setTags(customTags);
+        } else {
+          setAmount(formatAmount(editData.amount.toString()));
+          setNote(editData.note ?? "");
+          setTags(editData.tags ?? "");
+        }
       } else {
         setType("EXPENSE");
         setCategoryId("");
@@ -89,14 +121,37 @@ export function AddTransactionModal({
     const numeric = parseFloat(amount.replace(/,/g, ""));
     if (!categoryId || !amount || !transDate || isNaN(numeric) || numeric <= 0)
       return;
-    await onSave({
-      categoryId,
-      type,
-      amount: numeric,
-      note: note || undefined,
-      tags: tags || undefined,
-      transDate,
-    });
+
+    if (isCoPayTx) {
+      const split = calculateCoPaymentSplit(numeric);
+      const originalTags = tags
+        .split(",")
+        .map((t) => t.trim())
+        .filter((t) => t && t !== "ไทยช่วยไทย" && t !== "60-40");
+      const formatted = formatCoPaymentDetails(
+        numeric,
+        split.subsidyAmount,
+        note || undefined,
+        originalTags,
+      );
+      await onSave({
+        categoryId,
+        type,
+        amount: split.userAmount,
+        note: formatted.note,
+        tags: formatted.tags.join(","),
+        transDate,
+      });
+    } else {
+      await onSave({
+        categoryId,
+        type,
+        amount: numeric,
+        note: note || undefined,
+        tags: tags || undefined,
+        transDate,
+      });
+    }
   };
 
   return (
@@ -227,7 +282,7 @@ export function AddTransactionModal({
                 id="transaction-amount-label"
                 className="text-foreground text-sm font-semibold"
               >
-                จำนวนเงิน
+                {isCoPayTx ? "ยอดเต็ม (ไทยช่วยไทย 60/40)" : "จำนวนเงิน"}
               </Label>
               <Input
                 id="transaction-amount-input"
@@ -236,9 +291,16 @@ export function AddTransactionModal({
                 value={amount}
                 onChange={(e) => setAmount(formatAmount(e.target.value))}
                 required
-                placeholder="จำนวนเงิน (บาท)"
+                placeholder={
+                  isCoPayTx ? "ยอดรวมก่อนหักส่วนลด (บาท)" : "จำนวนเงิน (บาท)"
+                }
                 className="border-border bg-background placeholder:text-muted-foreground/60 focus-visible:ring-foreground/30 h-12 rounded-lg px-4 text-base font-medium"
               />
+              {isCoPayTx && (
+                <p className="text-muted-foreground text-xs">
+                  ระบุยอดเต็ม — ระบบจะคำนวณส่วนลด 60% ให้อัตโนมัติ
+                </p>
+              )}
             </div>
 
             <PopoverDatePicker

--- a/src/features/line/commands/handleExpenseCommand.ts
+++ b/src/features/line/commands/handleExpenseCommand.ts
@@ -833,23 +833,53 @@ async function handleEdit(
         return;
       }
 
-      const updated = await updateTransaction(latest.id, userId, {
-        amount: newAmount,
-      });
+      const isCoPayTx = shouldApplyCoPayment(
+        latest.type,
+        latest.note,
+        latest.tags?.split(","),
+      );
+      let updateData: {
+        amount: number;
+        note?: string | null;
+        tags?: string | null;
+      };
+      if (isCoPayTx) {
+        const split = calculateCoPaymentSplit(newAmount);
+        const customNoteMatch = (latest.note ?? "").match(/ - (.+)$/);
+        const customNote = customNoteMatch?.[1];
+        const originalTags = (latest.tags ?? "")
+          .split(",")
+          .map((t) => t.trim())
+          .filter((t) => t && t !== "ไทยช่วยไทย" && t !== "60-40");
+        const formatted = formatCoPaymentDetails(
+          newAmount,
+          split.subsidyAmount,
+          customNote,
+          originalTags,
+        );
+        updateData = {
+          amount: split.userAmount,
+          note: formatted.note,
+          tags: formatted.tags.join(","),
+        };
+      } else {
+        updateData = { amount: newAmount };
+      }
+
+      const updated = await updateTransaction(latest.id, userId, updateData);
       const isIncome = updated.type === "INCOME";
       const sign = isIncome ? "+" : "-";
-
+      const lines = [
+        "✅ แก้ไขจำนวนเงินสำเร็จ",
+        "",
+        `${updated.category.icon ?? "📦"} ${updated.category.name}`,
+        isCoPayTx
+          ? `🛍️ ยอดเต็ม ${fmt(newAmount, hide)} บาท → ชำระ ${fmt(updated.amount, hide)} บาท`
+          : `💵 ${sign}${fmt(updated.amount, hide)} บาท`,
+        `📅 ${updated.transDate}`,
+      ];
       await sendMessage(req as Parameters<typeof sendMessage>[0], [
-        {
-          type: "text",
-          text: [
-            "✅ แก้ไขจำนวนเงินสำเร็จ",
-            "",
-            `${updated.category.icon ?? "📦"} ${updated.category.name}`,
-            `💵 ${sign}${fmt(updated.amount, hide)} บาท`,
-            `📅 ${updated.transDate}`,
-          ].join("\n"),
-        },
+        { type: "text", text: lines.join("\n") },
       ]);
       return;
     }
@@ -874,23 +904,53 @@ async function handleEdit(
         return;
       }
 
-      const updated = await updateTransaction(latest.id, userId, {
-        amount: newAmount,
-      });
+      const isCoPayTx = shouldApplyCoPayment(
+        latest.type,
+        latest.note,
+        latest.tags?.split(","),
+      );
+      let updateData: {
+        amount: number;
+        note?: string | null;
+        tags?: string | null;
+      };
+      if (isCoPayTx) {
+        const split = calculateCoPaymentSplit(newAmount);
+        const customNoteMatch = (latest.note ?? "").match(/ - (.+)$/);
+        const customNote = customNoteMatch?.[1];
+        const originalTags = (latest.tags ?? "")
+          .split(",")
+          .map((t) => t.trim())
+          .filter((t) => t && t !== "ไทยช่วยไทย" && t !== "60-40");
+        const formatted = formatCoPaymentDetails(
+          newAmount,
+          split.subsidyAmount,
+          customNote,
+          originalTags,
+        );
+        updateData = {
+          amount: split.userAmount,
+          note: formatted.note,
+          tags: formatted.tags.join(","),
+        };
+      } else {
+        updateData = { amount: newAmount };
+      }
+
+      const updated = await updateTransaction(latest.id, userId, updateData);
       const isIncome = updated.type === "INCOME";
       const sign = isIncome ? "+" : "-";
-
+      const lines = [
+        "✅ แก้ไขจำนวนเงินสำเร็จ",
+        "",
+        `${updated.category.icon ?? "📦"} ${updated.category.name}`,
+        isCoPayTx
+          ? `🛍️ ยอดเต็ม ${fmt(newAmount, hide)} บาท → ชำระ ${fmt(updated.amount, hide)} บาท`
+          : `💵 ${sign}${fmt(updated.amount, hide)} บาท`,
+        `📅 ${updated.transDate}`,
+      ];
       await sendMessage(req as Parameters<typeof sendMessage>[0], [
-        {
-          type: "text",
-          text: [
-            "✅ แก้ไขจำนวนเงินสำเร็จ",
-            "",
-            `${updated.category.icon ?? "📦"} ${updated.category.name}`,
-            `💵 ${sign}${fmt(updated.amount, hide)} บาท`,
-            `📅 ${updated.transDate}`,
-          ].join("\n"),
-        },
+        { type: "text", text: lines.join("\n") },
       ]);
       return;
     }


### PR DESCRIPTION
## Summary

- **Web UI**: when editing a ทชท transaction, the modal now shows the full bill amount (reconstructed from stored 40% share + parsed subsidy) instead of the 40% user share — label updated to "ยอดเต็ม (ไทยช่วยไทย 60/40)" with a hint. On save, `calculateCoPaymentSplit` is applied and note/tags are regenerated.
- **LINE bot**: `/expense edit [amount]` and `/expense edit amount [value]` now detect ทชท transactions (via note/tags keywords) and treat the input as total bill — splits 60/40, updates `amount`, regenerates note and tags. Reply shows "ยอดเต็ม X บาท → ชำระ Y บาท".

## Test plan

- [ ] Edit a ทชท transaction from web UI — modal shows full bill, label says "ยอดเต็ม (ไทยช่วยไทย 60/40)"
- [ ] Change amount and save — stored amount is 40% share, note reflects new totals
- [ ] LINE bot: `/expense edit 300` on a ทชท transaction — stores 120 (40%), note updated to ยอดเต็ม 300
- [ ] Normal (non-ทชท) transactions unaffected