### PR TITLE
fix(expenses): toast notifications + await refetch after CRUD

### DIFF
--- a/src/features/expenses/hooks/useExpenseTransactions.ts
+++ b/src/features/expenses/hooks/useExpenseTransactions.ts
@@ -5,13 +5,14 @@ import type { CreateTransactionInput } from "../types";
 export function useExpenseTransactions(currentMonth: string, enabled: boolean) {
   const queryClient = useQueryClient();
 
-  const invalidate = () => {
-    void queryClient.invalidateQueries({
-      queryKey: ["expenses-overview", currentMonth],
-    });
-    void queryClient.invalidateQueries({ queryKey: ["expenses-multi-month"] });
-    void queryClient.invalidateQueries({ queryKey: ["expense-budgets"] });
-  };
+  const invalidate = () =>
+    Promise.all([
+      queryClient.invalidateQueries({
+        queryKey: ["expenses-overview", currentMonth],
+      }),
+      queryClient.invalidateQueries({ queryKey: ["expenses-multi-month"] }),
+      queryClient.invalidateQueries({ queryKey: ["expense-budgets"] }),
+    ]);
 
   const {
     data: overview,

--- a/src/features/expenses/hooks/useTransactionModal.ts
+++ b/src/features/expenses/hooks/useTransactionModal.ts
@@ -1,4 +1,5 @@
 import { useCallback, useState } from "react";
+import { useToast } from "@/components/common/ToastProvider";
 import type { CreateTransactionInput, TransactionWithCategory } from "../types";
 
 interface Deps {
@@ -17,6 +18,7 @@ export function useTransactionModal({
   updateTransaction,
   deleteTransaction,
 }: Deps) {
+  const { showToast } = useToast();
   const [showModal, setShowModal] = useState(false);
   const [editingTx, setEditingTx] = useState<TransactionWithCategory | null>(
     null,
@@ -39,14 +41,20 @@ export function useTransactionModal({
 
   const handleSave = useCallback(
     async (input: Omit<CreateTransactionInput, "userId">) => {
-      if (editingTx) {
-        await updateTransaction({ id: editingTx.id, input });
-      } else {
-        await createTransaction(input);
+      try {
+        if (editingTx) {
+          await updateTransaction({ id: editingTx.id, input });
+          showToast({ title: "✅ แก้ไขรายการสำเร็จ", type: "success" });
+        } else {
+          await createTransaction(input);
+          showToast({ title: "✅ บันทึกรายการสำเร็จ", type: "success" });
+        }
+        close();
+      } catch {
+        showToast({ title: "❌ เกิดข้อผิดพลาด กรุณาลองใหม่", type: "error" });
       }
-      close();
     },
-    [editingTx, createTransaction, updateTransaction, close],
+    [editingTx, createTransaction, updateTransaction, close, showToast],
   );
 
   const handleDelete = useCallback(


### PR DESCRIPTION
## Summary

- Show success toast after creating/editing a transaction
- Show error toast if create/update fails (previously silent)
- Fix UI not updating after edit: `invalidate()` now returns `Promise.all([...])` so TanStack Query awaits all refetches before resolving `mutateAsync` — list is fresh before modal closes and toast appears

## Root cause

`void queryClient.invalidateQueries(...)` fired and forgot — refetch ran in background while modal already closed with stale data shown.

## Test plan

- [ ] Edit transaction → list updates immediately + "✅ แก้ไขรายการสำเร็จ" toast
- [ ] Create transaction → list updates immediately + "✅ บันทึกรายการสำเร็จ" toast
- [ ] Simulate network error → "❌ เกิดข้อผิดพลาด กรุณาลองใหม่" toast, modal stays open