### PR TITLE
feat(line): admin approval flow via LINE + expense UI fixes

### DIFF
--- a/src/components/common/ToastProvider.tsx
+++ b/src/components/common/ToastProvider.tsx
@@ -22,13 +22,15 @@ export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({
 }) => {
   const [open, setOpen] = React.useState(false);
   const [toast, setToast] = React.useState<ToastData | null>(null);
-  const timerRef = React.useRef<NodeJS.Timeout | undefined>(undefined);
+  // เปลี่ยน key ทุกครั้งเพื่อ force remount Root → Radix เริ่ม duration timer ใหม่เสมอ
+  // รูปแบบเดิม (setOpen(false) → reopen หลัง 10ms) ไปแกะ controlled open ทำให้
+  // duration timer ไม่ทำงาน → toast ค้าง ไม่ auto-dismiss
+  const [toastKey, setToastKey] = React.useState(0);
 
   const showToast = React.useCallback((data: ToastData) => {
     setToast(data);
-    setOpen(false);
-    clearTimeout(timerRef.current);
-    timerRef.current = setTimeout(() => setOpen(true), 10);
+    setToastKey((k) => k + 1);
+    setOpen(true);
   }, []);
 
   return (
@@ -36,6 +38,7 @@ export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({
       <ToastPrimitive.Provider swipeDirection="right">
         {children}
         <ToastPrimitive.Root
+          key={toastKey}
           open={open}
           onOpenChange={setOpen}
           duration={toast?.duration ?? 3500}

--- a/src/features/expenses/hooks/useTransactionModal.ts
+++ b/src/features/expenses/hooks/useTransactionModal.ts
@@ -1,5 +1,4 @@
 import { useCallback, useState } from "react";
-import { useToast } from "@/components/common/ToastProvider";
 import type { CreateTransactionInput, TransactionWithCategory } from "../types";
 
 interface Deps {
@@ -18,7 +17,6 @@ export function useTransactionModal({
   updateTransaction,
   deleteTransaction,
 }: Deps) {
-  const { showToast } = useToast();
   const [showModal, setShowModal] = useState(false);
   const [editingTx, setEditingTx] = useState<TransactionWithCategory | null>(
     null,
@@ -44,17 +42,15 @@ export function useTransactionModal({
       try {
         if (editingTx) {
           await updateTransaction({ id: editingTx.id, input });
-          showToast({ title: "✅ แก้ไขรายการสำเร็จ", type: "success" });
         } else {
           await createTransaction(input);
-          showToast({ title: "✅ บันทึกรายการสำเร็จ", type: "success" });
         }
         close();
-      } catch {
-        showToast({ title: "❌ เกิดข้อผิดพลาด กรุณาลองใหม่", type: "error" });
+      } catch (err) {
+        console.error("[Transaction] save failed:", err);
       }
     },
-    [editingTx, createTransaction, updateTransaction, close, showToast],
+    [editingTx, createTransaction, updateTransaction, close],
   );
 
   const handleDelete = useCallback(

--- a/src/features/expenses/pages/ExpensesPage.tsx
+++ b/src/features/expenses/pages/ExpensesPage.tsx
@@ -97,9 +97,18 @@ export function ExpensesPage() {
     };
 
     recoverPointerLock();
-    const intervalId = window.setInterval(recoverPointerLock, 500);
+    // MutationObserver: recovery ทันทีเมื่อ body style เปลี่ยน (modal เปิด/ปิด)
+    // แทนการ query DOM ทุก 500ms ตลอดเวลา
+    const observer = new MutationObserver(recoverPointerLock);
+    observer.observe(document.body, {
+      attributes: true,
+      attributeFilter: ["style"],
+    });
+    // backstop: กันเคส Radix ปิด modal ไม่ครบโดยไม่ mutate style (ลดจาก 500ms → 2s)
+    const intervalId = window.setInterval(recoverPointerLock, 2000);
 
     return () => {
+      observer.disconnect();
       window.clearInterval(intervalId);
       recoverPointerLock();
     };
@@ -165,20 +174,42 @@ export function ExpensesPage() {
 
   const fabRef = useRef<HTMLDivElement>(null);
 
-  // FAB glow animation
+  // FAB glow animation — RAF coalesce + cache center (FAB fixed → เปลี่ยนตำแหน่งตอน resize เท่านั้น)
   useEffect(() => {
     const el = fabRef.current;
     if (!el) return;
-    const onMove = (e: PointerEvent) => {
+
+    let cx = 0;
+    let cy = 0;
+    let rafId = 0;
+    let lastE: PointerEvent | null = null;
+
+    const recomputeCenter = () => {
       const rect = el.getBoundingClientRect();
-      const cx = rect.left + rect.width / 2;
-      const cy = rect.top + rect.height / 2;
+      cx = rect.left + rect.width / 2;
+      cy = rect.top + rect.height / 2;
+    };
+    const update = () => {
+      rafId = 0;
+      const e = lastE;
+      if (!e) return;
       let deg = (Math.atan2(e.clientY - cy, e.clientX - cx) * 180) / Math.PI;
       if (deg < 0) deg += 360;
       el.style.setProperty("--start", String(deg + 90));
     };
-    window.addEventListener("pointermove", onMove);
-    return () => window.removeEventListener("pointermove", onMove);
+    const onMove = (e: PointerEvent) => {
+      lastE = e;
+      if (!rafId) rafId = requestAnimationFrame(update);
+    };
+
+    recomputeCenter();
+    window.addEventListener("pointermove", onMove, { passive: true });
+    window.addEventListener("resize", recomputeCenter);
+    return () => {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("resize", recomputeCenter);
+      if (rafId) cancelAnimationFrame(rafId);
+    };
   }, []);
 
   const txModal = useTransactionModal({

--- a/src/features/line/commands/handleApprovalCheck.ts
+++ b/src/features/line/commands/handleApprovalCheck.ts
@@ -92,6 +92,17 @@ export const handleApprovalCheck = async (req: any): Promise<boolean> => {
     case APPROVAL_CHECK_RESULT.NEW:
       // 🆕 สร้าง request ใหม่ — แจ้งให้รอ
       await approvalService.sendPendingNewMessage(userId);
+      // 🔔 แจ้งเตือนแอดมินเกี่ยวกับคำขอใหม่ (fire-and-forget — ไม่บล็อก response ของผู้ขอ)
+      void approvalService
+        .notifyAdminsOfNewRequest({
+          userId,
+          displayName: profile.displayName,
+          pictureUrl: profile.pictureUrl,
+          statusMessage: profile.statusMessage,
+        })
+        .catch((err) =>
+          console.error("[handleApprovalCheck] notifyAdmins error:", err),
+        );
       return false;
 
     case APPROVAL_CHECK_RESULT.PENDING:

--- a/src/features/line/commands/handleExpenseCommand.ts
+++ b/src/features/line/commands/handleExpenseCommand.ts
@@ -200,11 +200,21 @@ function createExpenseSummaryBubble(
       type: "box",
       layout: "vertical",
       paddingAll: "12px",
+      spacing: "sm",
       contents: [
         {
           type: "button",
           style: "primary",
           color: headerColor,
+          action: {
+            type: "uri",
+            label: "🌐 เปิดดูในเว็บ",
+            uri: `${env.FRONTEND_URL}/expenses`,
+          },
+        },
+        {
+          type: "button",
+          style: "secondary",
           action: {
             type: "message",
             label: "📋 ดูรายการทั้งหมด",
@@ -621,7 +631,30 @@ async function handleList(
     }
 
     await sendMessage(req as Parameters<typeof sendMessage>[0], [
-      { type: "text", text: lines.filter(Boolean).join("\n").trim() },
+      {
+        type: "text",
+        text: lines.filter(Boolean).join("\n").trim(),
+        quickReply: {
+          items: [
+            {
+              type: "action",
+              action: {
+                type: "uri",
+                label: "🌐 เปิดดูในเว็บ",
+                uri: `${env.FRONTEND_URL}/expenses`,
+              },
+            },
+            {
+              type: "action",
+              action: {
+                type: "message",
+                label: "📊 สรุปเดือนนี้",
+                text: "/expense",
+              },
+            },
+          ],
+        },
+      },
     ]);
   } catch (err) {
     console.error("[Expense List] error:", err);
@@ -1533,7 +1566,7 @@ async function handleAdd(
       },
       footer: {
         type: "box",
-        layout: "horizontal",
+        layout: "vertical",
         paddingAll: "12px",
         spacing: "sm",
         contents: [
@@ -1541,22 +1574,38 @@ async function handleAdd(
             type: "button",
             style: "primary",
             color: headerColor,
-            flex: 1,
             action: {
-              type: "message",
-              label: "📊 ดูสรุปเดือนนี้",
-              text: "/expense",
+              type: "uri",
+              label: "🌐 เปิดดูในเว็บ",
+              uri: `${env.FRONTEND_URL}/expenses`,
             },
           },
           {
-            type: "button",
-            style: "secondary",
-            flex: 1,
-            action: {
-              type: "message",
-              label: "📋 ดูรายการ",
-              text: "/expense list",
-            },
+            type: "box",
+            layout: "horizontal",
+            spacing: "sm",
+            contents: [
+              {
+                type: "button",
+                style: "secondary",
+                flex: 1,
+                action: {
+                  type: "message",
+                  label: "📊 สรุปเดือนนี้",
+                  text: "/expense",
+                },
+              },
+              {
+                type: "button",
+                style: "secondary",
+                flex: 1,
+                action: {
+                  type: "message",
+                  label: "📋 ดูรายการ",
+                  text: "/expense list",
+                },
+              },
+            ],
           },
         ],
       },

--- a/src/features/line/commands/handlePostback.ts
+++ b/src/features/line/commands/handlePostback.ts
@@ -10,16 +10,63 @@ import { handleCheckInMenu } from "./handleCheckInMenu";
 import { handleMonthlyReport } from "./handleMonthlyReport";
 import { handleReportMenu } from "./handleReportMenu";
 import { getLineUserAccount } from "../utils/getLineUserAccount";
+import { canManageApprovalsAsync } from "@/lib/auth/admin";
+import { approvalService } from "../services/approval.service.server";
+import { approvalBubbleTemplate } from "@/lib/validation/line-approval";
+
+/**
+ * 🔐 Admin action: อนุมัติผู้ใช้ผ่านปุ่มในข้อความแจ้งเตือนแอดมิน
+ * ตรวจสิทธิ์ admin ก่อนเสมอ (defense-in-depth — กันผู้ใช้ทั่วไปกดปุ่ม)
+ */
+const handleAdminApprove = async (
+  req: any,
+  event: any,
+  params: URLSearchParams,
+) => {
+  const adminLineUserId = event?.source?.userId;
+
+  const replyResult = (ok: boolean, message: string) =>
+    sendMessage(
+      req,
+      flexMessage(approvalBubbleTemplate.adminApproveResult({ ok, message })),
+    );
+
+  if (!adminLineUserId) {
+    return replyResult(false, "ไม่สามารถระบุตัวตนผู้กดปุ่มได้");
+  }
+
+  const isAdmin = await canManageApprovalsAsync(adminLineUserId);
+  if (!isAdmin) {
+    return replyResult(false, "คุณไม่มีสิทธิ์อนุมัติผู้ใช้");
+  }
+
+  const targetUid = params.get("uid");
+  if (!targetUid) {
+    return replyResult(false, "ข้อมูลคำขอไม่ครบถ้วน");
+  }
+
+  const result = await approvalService.approveByLineUser(
+    targetUid,
+    adminLineUserId,
+  );
+  return replyResult(result.ok, result.message);
+};
 
 export const handlePostback = async (req: any, event: any) => {
+  const data = event.postback.data;
+  const params = new URLSearchParams(data);
+  const action = params.get("action");
+
+  // 🔐 Admin actions — ตรวจสิทธิ์ admin แยกจาก flow ปกติ (ไม่ต้องผ่าน getLineUserAccount)
+  if (action === "admin_approve") {
+    return handleAdminApprove(req, event, params);
+  }
+
   const userPermission = await getLineUserAccount(event);
   if (!userPermission) {
     const payload = bubbleTemplate.signIn();
     return sendMessage(req, flexMessage(payload));
   }
-  const data = event.postback.data;
-  const params = new URLSearchParams(data);
-  const action = params.get("action");
   switch (action) {
     case "checkin": {
       const currentAttendance = await attendanceService.getTodayAttendance(

--- a/src/features/line/services/approval.repository.server.ts
+++ b/src/features/line/services/approval.repository.server.ts
@@ -256,6 +256,18 @@ const findDatabaseAdminLineUserIds = async (
 };
 
 /**
+ * ดึง LINE user IDs ของ admin ทั้งหมดจากฐานข้อมูล (user.role = "admin")
+ * ใช้สำหรับส่งแจ้งเตือนไปยังแอดมินทุกคน
+ */
+const findAllAdminLineUserIds = async (): Promise<string[]> => {
+  const accounts = await db.account.findMany({
+    where: { providerId: "line", user: { role: "admin" } },
+    select: { accountId: true },
+  });
+  return accounts.map((account) => account.accountId);
+};
+
+/**
  * ตั้งหรือยกเลิกสิทธิ์ admin ให้ user จาก LINE user ID
  */
 const updateAdminByLineUserId = async (
@@ -347,6 +359,7 @@ export const approvalRepository = {
   findLineAccounts,
   findLineAccountsByIds,
   findDatabaseAdminLineUserIds,
+  findAllAdminLineUserIds,
   updateAdminByLineUserId,
   markNotified,
   getStats,

--- a/src/features/line/services/approval.service.server.ts
+++ b/src/features/line/services/approval.service.server.ts
@@ -3,10 +3,16 @@
  * Business logic สำหรับ LINE Messaging API Approval Flow
  */
 import { approvalRepository } from "./approval.repository.server";
-import { canManageApprovals, isAdminLineUser } from "@/lib/auth/admin";
+import {
+  canManageApprovals,
+  canManageApprovalsAsync,
+  getEnvAdminLineUserIds,
+  isAdminLineUser,
+} from "@/lib/auth/admin";
 import { sendPushMessage } from "@/lib/utils/line-push";
 import { approvalBubbleTemplate } from "@/lib/validation/line-approval";
 import { flexMessage } from "@/lib/utils/line-message-utils";
+import { env } from "@/env.mjs";
 import type { ApprovalStatus, LineApprovalRequest } from "@prisma/client";
 import type { ApprovalCheckResult } from "../types/approval.types";
 import { APPROVAL_CHECK_RESULT } from "../types/approval.types";
@@ -57,8 +63,9 @@ export interface AccountApprovalItem {
 const checkApprovalStatus = async (
   userProfile: LineUserProfile,
 ): Promise<ApprovalCheckResult> => {
-  // 🔐 Admin whitelist check — ผู้อยู่ใน ADMIN_LINE_USER_IDS ได้รับอนุมัติอัตโนมัติ
-  if (isAdminLineUser(userProfile.userId)) {
+  // 🔐 Admin check — แอดมิน (env whitelist หรือ DB role) ได้รับอนุมัติอัตโนมัติ
+  // ทำให้แอดมินทุกประเภทสามารถใช้งานคำสั่งและกดปุ่มอนุมัติใน LINE ได้
+  if (await canManageApprovalsAsync(userProfile.userId)) {
     const existing = await approvalRepository.findByLineUserId(
       userProfile.userId,
     );
@@ -227,6 +234,96 @@ const rejectLineUser = async (
 };
 
 /**
+ * ดึง LINE user IDs ของแอดมินทั้งหมด (รวม env whitelist และ DB role)
+ * ใช้สำหรับส่งแจ้งเตือนไปยังแอดมินทุกคน
+ */
+const getAdminLineUserIds = async (): Promise<string[]> => {
+  const envAdmins = getEnvAdminLineUserIds();
+  const dbAdmins = await approvalRepository.findAllAdminLineUserIds();
+  return Array.from(new Set([...envAdmins, ...dbAdmins]));
+};
+
+/**
+ * แจ้งเตือนแอดมินทุกคนเมื่อมีคำขอใหม่รออนุมัติ
+ * ส่ง flex message พร้อมข้อมูลผู้ขอครบถ้วนและปุ่มอนุมัติใน LINE
+ * (fire-and-forget — ไม่บล็อกการตอบกลับผู้ขอ)
+ */
+const notifyAdminsOfNewRequest = async (
+  requester: LineUserProfile,
+): Promise<void> => {
+  try {
+    const adminIds = await getAdminLineUserIds();
+    if (adminIds.length === 0) {
+      console.warn(
+        "[ApprovalService] ไม่พบแอดมินในระบบ — ข้ามการแจ้งเตือนคำขอใหม่",
+      );
+      return;
+    }
+
+    // กรองตัวผู้ขอออก (ถ้าบังเอิญเป็นแอดมิน — ปกติแอดมิน auto-approve จึงไม่ถึงจุดนี้)
+    const recipients = adminIds.filter((id) => id !== requester.userId);
+    if (recipients.length === 0) return;
+
+    const stats = await approvalRepository.getStats();
+    const webUrl = `${env.APP_URL}/line-approval`;
+    const bubble = approvalBubbleTemplate.adminPendingRequest({
+      displayName: requester.displayName,
+      pictureUrl: requester.pictureUrl,
+      lineUserId: requester.userId,
+      statusMessage: requester.statusMessage,
+      pendingCount: stats.pending,
+      webUrl,
+    });
+
+    const results = await Promise.allSettled(
+      recipients.map((adminId) =>
+        sendPushMessage(adminId, flexMessage(bubble)),
+      ),
+    );
+    const failed = results.filter((r) => r.status === "rejected").length;
+    if (failed > 0) {
+      console.error(
+        `[ApprovalService] ส่งแจ้งเตือนแอดมินล้มเหลว ${failed}/${recipients.length} รายการ`,
+      );
+    }
+  } catch (err) {
+    console.error("[ApprovalService] notifyAdminsOfNewRequest error:", err);
+  }
+};
+
+/**
+ * Admin: อนุมัติ LINE user ผ่านปุ่มใน LINE (อ้างอิงด้วย lineUserId)
+ * ใช้กับ postback action=admin_approve จากข้อความแจ้งเตือนแอดมิน
+ */
+const approveByLineUser = async (
+  targetLineUserId: string,
+  adminLineUserId: string,
+): Promise<{ ok: boolean; message: string; displayName?: string | null }> => {
+  const existing = await approvalRepository.findByLineUserId(targetLineUserId);
+  if (!existing) {
+    return { ok: false, message: "ไม่พบคำขอของผู้ใช้ LINE นี้ในระบบ" };
+  }
+  if (existing.status === APPROVAL_CHECK_RESULT.APPROVED) {
+    return {
+      ok: false,
+      message: `ผู้ใช้นี้ได้รับการอนุมัติไปแล้ว${
+        existing.displayName ? ` (${existing.displayName})` : ""
+      }`,
+      displayName: existing.displayName,
+    };
+  }
+
+  const record = await approveUser(existing.id, adminLineUserId);
+  return {
+    ok: true,
+    message: `อนุมัติ ${
+      record.displayName ?? "ผู้ใช้งาน"
+    } เรียบร้อยแล้ว — ระบบส่งการแจ้งเตือนให้ผู้ใช้ทราบทันที`,
+    displayName: record.displayName,
+  };
+};
+
+/**
  * ดึงรายการ requests สำหรับ admin
  * fallback name/image จาก LINE Login OAuth account ถ้า displayName/pictureUrl ว่าง
  */
@@ -387,6 +484,9 @@ export const approvalService = {
   approveUser,
   rejectUser,
   rejectLineUser,
+  approveByLineUser,
+  notifyAdminsOfNewRequest,
+  getAdminLineUserIds,
   unlockRejectedUser,
   getApprovalList,
   getAccountApprovalList,

--- a/src/lib/auth/admin.ts
+++ b/src/lib/auth/admin.ts
@@ -6,25 +6,25 @@ import { env } from "@/env.mjs";
 import { db } from "@/lib/database/db";
 
 /**
+ * ดึงรายการ admin LINE user IDs จาก env whitelist (ADMIN_LINE_USER_IDS)
+ * @returns array ของ LINE userId ที่เป็น admin ตาม env
+ */
+export const getEnvAdminLineUserIds = (): string[] => {
+  const adminIds = env.ADMIN_LINE_USER_IDS;
+  if (!adminIds || adminIds.trim() === "") return [];
+  return adminIds
+    .split(",")
+    .map((id) => id.trim())
+    .filter(Boolean);
+};
+
+/**
  * ตรวจสอบว่า LINE userId อยู่ใน whitelist admin หรือไม่
  * @param lineUserId LINE userId (accountId)
  * @returns true ถ้าเป็น admin
  */
 export const isAdminLineUser = (lineUserId: string): boolean => {
-  const adminIds = env.ADMIN_LINE_USER_IDS;
-
-  // ถ้าไม่ได้ตั้งค่า → ไม่มี admin ใดๆ (ปลอดภัย default)
-  if (!adminIds || adminIds.trim() === "") {
-    return false;
-  }
-
-  // Parse comma-separated list
-  const whitelist = adminIds
-    .split(",")
-    .map((id) => id.trim())
-    .filter(Boolean);
-
-  return whitelist.includes(lineUserId);
+  return getEnvAdminLineUserIds().includes(lineUserId);
 };
 
 /**

--- a/src/lib/validation/line-approval.ts
+++ b/src/lib/validation/line-approval.ts
@@ -24,6 +24,13 @@ const GRADIENT_REJECTED = {
   endColor: "#dc2626",
 };
 
+const GRADIENT_ADMIN = {
+  type: "linearGradient",
+  angle: "135deg",
+  startColor: "#6366f1",
+  endColor: "#4338ca",
+};
+
 /**
  * ส่งให้ user ครั้งแรก — รอการอนุมัติ (NEW)
  */
@@ -512,9 +519,233 @@ const rejected = (rejectReason?: string | null) => {
   ];
 };
 
+interface AdminPendingRequestParams {
+  displayName?: string | null;
+  pictureUrl?: string | null;
+  lineUserId: string;
+  statusMessage?: string | null;
+  pendingCount: number;
+  webUrl: string;
+}
+
+/**
+ * ส่งให้แอดมิน — มีคำขอใหม่รออนุมัติ พร้อมข้อมูลผู้ขอและปุ่มอนุมัติใน LINE
+ * (ปฏิเสธให้ทำบนเว็บ เพื่อระบุเหตุผลได้ครบถ้วน)
+ */
+const adminPendingRequest = (params: AdminPendingRequestParams) => {
+  const {
+    displayName,
+    pictureUrl,
+    lineUserId,
+    statusMessage,
+    pendingCount,
+    webUrl,
+  } = params;
+
+  const name = displayName?.trim() || "ผู้ใช้งานใหม่";
+  const timeText = new Date().toLocaleString("th-TH", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+
+  const infoRow = (label: string, value: string, valueColor = "#374151") => ({
+    type: "box",
+    layout: "horizontal",
+    contents: [
+      { type: "text", text: label, size: "sm", color: "#6b7280", flex: 3 },
+      {
+        type: "text",
+        text: value,
+        size: "sm",
+        color: valueColor,
+        weight: "bold",
+        flex: 5,
+        wrap: true,
+      },
+    ],
+  });
+
+  return [
+    {
+      type: "bubble",
+      size: "mega",
+      header: {
+        type: "box",
+        layout: "vertical",
+        paddingAll: "20px",
+        background: GRADIENT_ADMIN,
+        contents: [
+          {
+            type: "box",
+            layout: "horizontal",
+            contents: [
+              {
+                type: "text",
+                text: "🔔",
+                size: "xxl",
+                flex: 0,
+              },
+              {
+                type: "box",
+                layout: "vertical",
+                flex: 1,
+                paddingStart: "12px",
+                contents: [
+                  {
+                    type: "text",
+                    text: "มีคำขอใหม่รออนุมัติ",
+                    color: "#ffffff",
+                    weight: "bold",
+                    size: "lg",
+                  },
+                  {
+                    type: "text",
+                    text: "ต้องการการตรวจสอบจากแอดมิน",
+                    color: "#e0e7ff",
+                    size: "sm",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      ...(pictureUrl
+        ? {
+            hero: {
+              type: "image",
+              url: pictureUrl,
+              size: "full",
+              aspectRatio: "20:13",
+              aspectMode: "cover",
+              backgroundColor: "#f3f4f6",
+            },
+          }
+        : {}),
+      body: {
+        type: "box",
+        layout: "vertical",
+        paddingAll: "20px",
+        spacing: "md",
+        contents: [
+          {
+            type: "text",
+            text: name,
+            weight: "bold",
+            size: "xl",
+            color: "#111827",
+          },
+          ...(statusMessage?.trim()
+            ? [
+                {
+                  type: "text",
+                  text: statusMessage,
+                  wrap: true,
+                  size: "xs",
+                  color: "#6b7280",
+                  margin: "sm",
+                },
+              ]
+            : []),
+          {
+            type: "separator",
+            margin: "lg",
+          },
+          {
+            type: "box",
+            layout: "vertical",
+            margin: "lg",
+            spacing: "sm",
+            contents: [
+              infoRow("สถานะ", "🟡 รอการอนุมัติ", "#d97706"),
+              infoRow("คำขอค้างทั้งหมด", `${pendingCount} รายการ`),
+              infoRow("เวลาที่ขอ", timeText),
+              infoRow("LINE User ID", lineUserId, "#9ca3af"),
+            ],
+          },
+        ],
+      },
+      footer: {
+        type: "box",
+        layout: "vertical",
+        spacing: "sm",
+        contents: [
+          {
+            type: "button",
+            style: "primary",
+            color: "#059669",
+            height: "md",
+            action: {
+              type: "postback",
+              label: "✅ อนุมัติ",
+              data: `action=admin_approve&uid=${lineUserId}`,
+              displayText: `อนุมัติ ${name}`,
+            },
+          },
+          {
+            type: "button",
+            style: "link",
+            height: "md",
+            action: {
+              type: "uri",
+              label: "ดูรายละเอียด / ปฏิเสธบนเว็บ",
+              uri: webUrl,
+            },
+          },
+        ],
+      },
+    },
+  ];
+};
+
+/**
+ * ส่งให้แอดมิน — ผลการกดปุ่มอนุมัติใน LINE
+ */
+const adminApproveResult = (params: { ok: boolean; message: string }) => {
+  const { ok, message } = params;
+
+  return [
+    {
+      type: "bubble",
+      size: "kilo",
+      header: {
+        type: "box",
+        layout: "vertical",
+        paddingAll: "16px",
+        background: ok ? GRADIENT_APPROVED : GRADIENT_REJECTED,
+        contents: [
+          {
+            type: "text",
+            text: ok ? "✅ อนุมัติสำเร็จ" : "⚠️ ดำเนินการไม่สำเร็จ",
+            color: "#ffffff",
+            weight: "bold",
+            size: "md",
+          },
+        ],
+      },
+      body: {
+        type: "box",
+        layout: "vertical",
+        paddingAll: "16px",
+        contents: [
+          {
+            type: "text",
+            text: message,
+            wrap: true,
+            size: "sm",
+            color: ok ? "#374151" : "#dc2626",
+          },
+        ],
+      },
+    },
+  ];
+};
+
 export const approvalBubbleTemplate = {
   pendingNew,
   pendingWaiting,
   approved,
   rejected,
+  adminPendingRequest,
+  adminApproveResult,
 };


### PR DESCRIPTION
## Summary

- Add admin-based approval flow: on a new request, admins are notified via LINE and can approve through an `admin_approve` postback (with admin permission check)
- Add `ADMIN_LINE_USER_IDS` env whitelist (`getEnvAdminLineUserIds`, `isAdminLineUser`)
- Add admin notification bubble templates (`adminPendingRequest`, `adminApproveResult`) with admin gradient styling
- Fix `ToastProvider` remount via `toastKey` for reliable toast display
- Replace `ExpensesPage` 500ms poll with `MutationObserver` + 2s interval, and cap FAB animation with `requestAnimationFrame`
- Remove direct toast usage from `useTransactionModal`, log errors on catch

## Test plan

- [ ] New expense request → admins receive LINE notification bubble with approve button + web link
- [ ] Admin taps approve → request approved, requester gets confirmation; non-admin gets blocked
- [ ] Toasts display reliably (remount enforced via `toastKey`)
- [ ] ExpensesPage reflects data changes without high-frequency polling
- [ ] FAB animation stays smooth

🤖 Generated by [Oz](https://docs.warp.dev/o)