### PR TITLE
fix(deploy): run prisma migrate deploy on container startup

### DIFF
--- a/scripts/devops/docker-entrypoint.sh
+++ b/scripts/devops/docker-entrypoint.sh
@@ -23,15 +23,28 @@ fi
 
 echo "✅ Runtime environment verified"
 
-if [ "${RUN_DB_PUSH:-false}" = "true" ]; then
-    echo "🗄️ Running prisma db push..."
-    if bunx prisma db push --skip-generate 2>/dev/null; then
-        echo "✅ Prisma schema synced"
+# ─────────────────────────────────────────────
+# Database Migrations
+# ─────────────────────────────────────────────
+# Run pending migrations on every container start.
+# `migrate deploy` is idempotent — it only applies migrations not yet in the
+# `_prisma_migrations` table, so it's safe to run on every boot.
+#
+# Use `migrate deploy` (not `db push`) in production because:
+#   - Tracks applied migrations in history (db push does not)
+#   - Cannot cause data loss by design (migrations are authored, not generated)
+#   - Required by AGENTS.md: "ALWAYS use migrations for production schema changes"
+#
+# Opt out via RUN_MIGRATIONS=false (e.g. for read-only replicas or CI smoke tests).
+if [ "${RUN_MIGRATIONS:-true}" = "true" ]; then
+    echo "🗄️ Running prisma migrate deploy..."
+    if bunx prisma migrate deploy 2>&1; then
+        echo "✅ Database migrations applied"
     else
-        echo "⚠️ Prisma schema sync failed or database not available"
+        echo "⚠️ Database migration failed — starting app anyway (DB may be unavailable)"
     fi
 else
-    echo "⏭️ Prisma db push skipped (set RUN_DB_PUSH=true to enable)"
+    echo "⏭️ Prisma migrate deploy skipped (set RUN_MIGRATIONS=false to disable)"
 fi
 
 echo "🚀 Starting TanStack Start application..."


### PR DESCRIPTION
## Problem

PR #164 (Decimal migration) merged and deployed, but the production DB never received the migration. The Docker entrypoint used `prisma db push` which:

1. **Was never enabled** — gated behind `RUN_DB_PUSH=false` (default off), so it ran on literally zero deployments
2. **Does not track migration history** even when enabled — `_prisma_migrations` table never updated, so `migrate deploy` later would re-run migrations and fail

Result: every schema-changing PR ships code that expects the new schema, while the prod DB keeps the old one. For #164 this means Prisma expects `Decimal` columns but finds `Float`, causing runtime type mismatches.

Evidence: deploy logs for #164 show `prisma generate` runs during image build, but no `migrate` or `db push` step touches the prod DB:
```
Container bun-line-t3-app Healthy
✅ Application healthy
```
(Health check is a stub — it does not query the DB, so "healthy" masks the drift.)

## Fix

Switch the entrypoint from `db push` to `migrate deploy`, and default it to **on**:

| Before | After |
|---|---|
| `RUN_DB_PUSH=false` (default off) | `RUN_MIGRATIONS=true` (default on) |
| `prisma db push` (no history) | `prisma migrate deploy` (tracked) |
| Skipped on every prior deploy | Runs on every container boot |

`migrate deploy` is idempotent — it only applies migrations not yet recorded in `_prisma_migrations`, so running it on every boot is safe and standard practice. This matches AGENTS.md: *"ALWAYS use migrations for production schema changes"*.

## Test plan

- [ ] Merge → CI builds new image with updated entrypoint
- [ ] Container boots → `prisma migrate deploy` runs → applies `20260704000000_expenses_decimal_amount` to prod DB
- [ ] Verify with `docker compose exec app bunx prisma migrate status` — should show 6 migrations applied
- [ ] Hit `/api/expenses/overview` with valid session → 200 (not 500 from type mismatch)

## Notes

- Opt out via `RUN_MIGRATIONS=false` for read-only replicas or CI smoke tests
- Migration failure no longer blocks app startup (logs warning, continues) — preserves the previous behavior so a DB blip doesn't take the app down